### PR TITLE
feat(footer): URLs dinámicas de reserva para ciudades

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -440,7 +440,7 @@ export default defineAppConfig({
       name: "Armenia",
       description:
         "¿Planeas visitar Armenia? En Armenia puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto El Edén. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como Salento, Filandia o el Parque del Café. Nuestra sede en Armenia te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en el corazón del Paisaje Cultural Cafetero, declarado Patrimonio de la Humanidad!",
-      link: "https://www.alquilerdecarrosarmenia.com/",
+      link: "/armenia",
       testimonials: [
         {
           user: {
@@ -515,7 +515,7 @@ export default defineAppConfig({
       name: "Barranquilla",
       description:
         "¿Planeas visitar Barranquilla? En Barranquilla puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Ernesto Cortissoz. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Malecón del Río, el Museo del Caribe o el Zoológico de Barranquilla. Nuestra sede en Barranquilla te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Puerta de Oro de Colombia, epicentro del Carnaval más famoso del país!",
-      link: "https://www.alquilerdecarrosbarranquilla.com/",
+      link: "/barranquilla",
       testimonials: [
         {
           user: {
@@ -590,7 +590,7 @@ export default defineAppConfig({
       name: "Bogotá",
       description:
         "¿Planeas visitar Bogotá? En Bogotá puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto El Dorado. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Museo del Oro, el Cerro de Monserrate o la Zona Rosa. Nuestra sede en Bogotá te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la capital a 2.600 metros más cerca de las estrellas!",
-      link: "https://www.alquilercarrosenbogota.co/",
+      link: "/bogota",
       testimonials: [
         {
           user: {
@@ -665,7 +665,7 @@ export default defineAppConfig({
       name: "Bucaramanga",
       description:
         "¿Planeas visitar Bucaramanga? En Bucaramanga puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Palonegro. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Parque Nacional del Chicamocha, el Ecoparque Cerro del Santísimo o el centro histórico. Nuestra sede en Bucaramanga te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad Bonita de Colombia, famosa por sus parques y aventura extrema!",
-      link: "https://www.alquilercarrosbucaramanga.com/",
+      link: "/bucaramanga",
       testimonials: [
         {
           user: {
@@ -740,7 +740,7 @@ export default defineAppConfig({
       name: "Cali",
       description:
         "¿Planeas visitar Cali? En Cali puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Alfonso Bonilla Aragón. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Zoológico de Cali, la Iglesia La Ermita o el Cristo Rey. Nuestra sede en Cali te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la capital mundial de la salsa, donde el ritmo nunca para!",
-      link: "https://www.alquilerdecarroscali.net/",
+      link: "/cali",
       testimonials: [
         {
           user: {
@@ -815,7 +815,7 @@ export default defineAppConfig({
       name: "Cartagena",
       description:
         "¿Planeas visitar Cartagena? En Cartagena puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Rafael Núñez. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Castillo de San Felipe, el Centro Histórico o las Islas del Rosario. Nuestra sede en Cartagena te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Heroica, joya colonial del Caribe!",
-      link: "https://www.alquilerdecarroscartagena.com/",
+      link: "/cartagena",
       testimonials: [
         {
           user: {
@@ -890,7 +890,7 @@ export default defineAppConfig({
       name: "Cúcuta",
       description:
         "¿Planeas visitar Cúcuta? En Cúcuta puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Camilo Daza. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Malecón, el Parque Santander o el Puente Internacional Simón Bolívar. Nuestra sede en Cúcuta te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Perla del Norte, puerta fronteriza con Venezuela!",
-      link: "https://www.alquilerdecarroscucuta.com/",
+      link: "/cucuta",
       testimonials: [
         {
           user: {
@@ -965,7 +965,7 @@ export default defineAppConfig({
       name: "Ibagué",
       description:
         "¿Planeas visitar Ibagué? En Ibagué puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Perales. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Cañón del Combeima, el Jardín Botánico San Jorge o el Conservatorio del Tolima. Nuestra sede en Ibagué te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Capital Musical de Colombia, cuna de festivales folclóricos!",
-      link: "https://www.alquilerdecarrosibague.com/",
+      link: "/ibague",
       testimonials: [
         {
           user: {
@@ -1040,7 +1040,7 @@ export default defineAppConfig({
       name: "Manizales",
       description:
         "¿Planeas visitar Manizales? En Manizales puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto La Nubia. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como la Catedral Basílica, el Ecoparque Los Yarumos o el Nevado del Ruiz. Nuestra sede en Manizales te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad de las Puertas Abiertas, entre volcanes y café!",
-      link: "https://www.alquilerdecarrosmanizales.com/",
+      link: "/manizales",
       testimonials: [
         {
           user: {
@@ -1115,7 +1115,7 @@ export default defineAppConfig({
       name: "Medellín",
       description:
         "¿Planeas visitar Medellín? En Medellín puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto José María Córdova. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Parque Arví, la Comuna 13 o el Jardín Botánico. Nuestra sede en Medellín te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad de la Eterna Primavera, ejemplo de innovación urbana!",
-      link: "https://www.alquilercarrosmedellin.co/",
+      link: "/medellin",
       testimonials: [
         {
           user: {
@@ -1190,7 +1190,7 @@ export default defineAppConfig({
       name: "Montería",
       description:
         "¿Planeas visitar Montería? En Montería puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Los Garzones. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Río Sinú, el Parque Ronda del Sinú o el Sombrero Vueltiao. Nuestra sede en Montería te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Perla del Sinú, capital ganadera del Caribe!",
-      link: "https://www.alquilerdecarrosmonteria.com/",
+      link: "/monteria",
       testimonials: [
         {
           user: {
@@ -1265,7 +1265,7 @@ export default defineAppConfig({
       name: "Neiva",
       description:
         "¿Planeas visitar Neiva? En Neiva puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Benito Salas. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Desierto de la Tatacoa, el Parque Andino o el Festival del Bambuco. Nuestra sede en Neiva te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Puerta del Sur, cerca de maravillas arqueológicas!",
-      link: "https://www.alquilerdecarrosneiva.com/",
+      link: "/neiva",
       testimonials: [
         {
           user: {
@@ -1340,7 +1340,7 @@ export default defineAppConfig({
       name: "Pereira",
       description:
         "¿Planeas visitar Pereira? En Pereira puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Matecaña. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Bioparque Ukumarí, el Santuario de Fauna y Flora Otún Quimbaya o el Cerrito. Nuestra sede en Pereira te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Querendona, Trasnochadora y Morena del Eje Cafetero!",
-      link: "https://www.alquilerdecarrospereira.com/",
+      link: "/pereira",
       testimonials: [
         {
           user: {
@@ -1415,7 +1415,7 @@ export default defineAppConfig({
       name: "Santa Marta",
       description:
         "¿Planeas visitar Santa Marta? En Santa Marta puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Simón Bolívar. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Parque Tayrona, la Quinta de San Pedro Alejandrino o Taganga. Nuestra sede en Santa Marta te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Bahía Más Linda de América!",
-      link: "https://www.alquilercarrossantamarta.com/",
+      link: "/santamarta",
       testimonials: [
         {
           user: {
@@ -1490,7 +1490,7 @@ export default defineAppConfig({
       name: "Valledupar",
       description:
         "¿Planeas visitar Valledupar? En Valledupar puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Alfonso López. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Río Guatapurí, la Plaza Alfonso López o el Festival Vallenato. Nuestra sede en Valledupar te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Cuna del Vallenato, tierra de acordeones y leyendas!",
-      link: "https://www.alquilerdecarrosvalledupar.com/",
+      link: "/valledupar",
       testimonials: [
         {
           user: {
@@ -1565,7 +1565,7 @@ export default defineAppConfig({
       name: "Villavicencio",
       description:
         "¿Planeas visitar Villavicencio? En Villavicencio puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Vanguardia. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Bioparque Los Ocarros, el Mirador de Buenavista o Caño Cristales (cerca). Nuestra sede en Villavicencio te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Puerta al Llano, con sabores de llanero auténtico!",
-      link: "https://www.alquilercarrosvillavicencio.com/",
+      link: "/villavicencio",
       testimonials: [
         {
           user: {
@@ -1638,7 +1638,7 @@ export default defineAppConfig({
     {
       id: "floridablanca",
       name: "Floridablanca",
-      link: "https://www.alquilerdecarrosfloridablanca.com/",
+      link: "/floridablanca",
       testimonials: [
         {
           user: {
@@ -1713,7 +1713,7 @@ export default defineAppConfig({
       name: "Palmira",
       description:
         "¿Planeas visitar Floridablanca? En Floridablanca puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Palonegro (Bucaramanga). Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Ecoparque Cerro El Santísimo, el Jardín Botánico Eloy Valenzuela o Cañón del Chicamocha. Nuestra sede en Floridablanca te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad Dulce de Colombia, famosa por sus obleas!",
-      link: "https://www.alquilerdecarrospalmira.com/",
+      link: "/palmira",
       testimonials: [
         {
           user: {
@@ -1788,7 +1788,7 @@ export default defineAppConfig({
       name: "Soledad",
       description:
         "¿Planeas visitar Soledad? En Soledad puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Ernesto Cortissoz (Barranquilla). Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Malecón del Río, el Parque Sagrado Corazón o el Museo del Carnaval. Nuestra sede en Soledad te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en el municipio más poblado del Atlántico, vibrante y carnavalero!",
-      link: "https://www.alquilerdecarrossoledad.com/",
+      link: "/soledad",
       testimonials: [
         {
           user: {
@@ -1855,81 +1855,6 @@ export default defineAppConfig({
           },
           quote:
             "Excelente alternativa para recorrer Soledad. El auto fue perfecto para ir al Mercado Público y el Malecón, muy limpio, seguro y con buen consumo de gasolina.",
-        },
-      ],
-    },
-    {
-      id: "cancun",
-      name: "Cancún",
-      description:
-        "¿Planeas visitar Cancún? En Cancún puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Internacional de Cancún. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como las playas del Caribe, Chichén Itzá o Xcaret. Nuestra sede en Cancún te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en el paraíso maya del Caribe mexicano!",
-      link: "https://alquilerdecarroscancun.com/",
-      testimonials: [
-        {
-          user: {
-            name: "Stephany M. García",
-            description: "Peru",
-            avatar: {
-              src: "uifaces-popular-image5",
-              alt: "Stephany M. García",
-            },
-          },
-          quote:
-            "Durante nuestra estadía en Cancún, tuvimos la oportunidad de visitar Chichén Itzá y Isla Mujeres. Fue muy cómodo desplazarse entre estos destinos y disfrutar de las ruinas mayas a nuestro propio ritmo.",
-        },
-        {
-          user: {
-            name: "Sandra Milena Barona",
-            description: "Colombia",
-            avatar: {
-              src: "uifaces-popular-image4",
-              alt: "Sandra Milena Barona",
-            },
-          },
-          quote:
-            "Hicimos una parada en los cenotes al final de la tarde, después de explorar Playa Delfines. Contar con transporte propio nos dio la libertad de hacer ese recorrido sin prisas y apreciar las aguas cristalinas.",
-        },
-        {
-          user: {
-            name: "Luis Javier Rodríguez M.",
-            description: "Honduras",
-            avatar: {
-              src: "uifaces-popular-image3",
-              alt: "Luis Javier Rodríguez M.",
-            },
-          },
-          quote:
-            "En Cancún, visitamos el Museo Subacuático y Xcaret. Tener un auto nos permitió movernos con facilidad y disfrutar de la aventura sin preocupaciones.",
-        },
-        {
-          user: {
-            name: "Carlos Andrés Mejía",
-            description: "Colombia",
-            avatar: {
-              src: "uifaces-popular-image2",
-              alt: "Carlos Andrés Mejía",
-            },
-          },
-          quote:
-            "Me encantó el servicio en Cancún. Todo muy puntual y el carro en excelente estado. Pude conocer Chichén Itzá y Isla Mujeres sin complicaciones. ¡Totalmente recomendado!",
-        },
-        {
-          user: {
-            name: "Ana Lucía Torres",
-            description: "Ecuador",
-            avatar: { src: "uifaces-human-image6", alt: "Ana Lucía Torres" },
-          },
-          quote:
-            "Viajar en familia a Cancún fue muy fácil gracias a este servicio de alquiler. Recorrimos los cenotes y Playa Delfines, con buen precio y excelente atención.",
-        },
-        {
-          user: {
-            name: "Esteban Páez",
-            description: "Colombia",
-            avatar: { src: "uifaces-popular-image", alt: "Esteban Páez" },
-          },
-          quote:
-            "Excelente alternativa para recorrer Cancún. El auto fue perfecto para ir al Museo Subacuático y Xcaret, muy limpio, seguro y con buen consumo de gasolina.",
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Footer ahora genera URLs completas de reserva con fechas dinámicas y sucursal de aeropuerto
- Quita botón de Cancún (no tiene sucursal disponible)
- Corrige URL de Santa Marta (usa `santamarta` en vez de `santa-marta` que daba 404)

## Test plan
- [ ] Verificar que los 19 botones de ciudades en el footer abren la página de reserva correctamente
- [ ] Confirmar que Santa Marta ya no da 404
- [ ] Confirmar que Cancún ya no aparece en el footer