### PR TITLE
perf(inp): optimizar watchers con flush sync y debounce [RIESGO ALTO]

### DIFF
--- a/app/composables/useSearch.ts
+++ b/app/composables/useSearch.ts
@@ -98,32 +98,36 @@ export default function useSearch() {
   };
   
   /** watchers */
+
+  // Watchers de sincronización pickup → return (flush: 'sync' evita cascada)
+  // Se ejecutan sincrónicamente antes del siguiente tick de Vue
   watch(
     lugarRecogida,
-    (newPickupLocation) => (lugarDevolucion.value = newPickupLocation)
-  );
-  
-  watch(fechaRecogida, (newPickupDate): void => {
-    if(selectedPickupDate.value)
-      fechaDevolucion.value = selectedPickupDate.value.copy().add({days: 7}).toString() ?? null
-  });
-  
-  watch(
-    horaRecogida,
-    (newPickupHour) => (horaDevolucion.value = newPickupHour)
+    (newPickupLocation) => (lugarDevolucion.value = newPickupLocation),
+    { flush: 'sync' }
   );
 
-  watch([
-    lugarRecogida,
-    lugarDevolucion,
-    fechaRecogida,
-    fechaDevolucion,
+  watch(fechaRecogida, (newPickupDate): void => {
+    if (selectedPickupDate.value)
+      fechaDevolucion.value = selectedPickupDate.value.copy().add({ days: 7 }).toString() ?? null
+  }, { flush: 'sync' });
+
+  watch(
     horaRecogida,
-    horaDevolucion
-  ], () => {
-    categoriesAvailabilityData.value=null;
-    animateSearchButton.value = true;
-  });
+    (newPickupHour) => (horaDevolucion.value = newPickupHour),
+    { flush: 'sync' }
+  );
+
+  // Watcher debounced para resetear disponibilidad
+  // Agrupa múltiples cambios rápidos en una sola ejecución (50ms)
+  watchDebounced(
+    [lugarRecogida, lugarDevolucion, fechaRecogida, fechaDevolucion, horaRecogida, horaDevolucion],
+    () => {
+      categoriesAvailabilityData.value = null;
+      animateSearchButton.value = true;
+    },
+    { debounce: 50 }
+  );
 
   // Desactivar animación cuando los vehículos están desplegados
   watch(categoriesAvailabilityData, (newValue) => {


### PR DESCRIPTION
## Summary

Reduce cascadas de watchers que disparan múltiples actualizaciones del DOM.

## Cambios

- **flush: 'sync'** en watchers pickup→return (lugar, fecha, hora)
  - Ejecuta sincronización antes del siguiente tick de Vue
  - Evita que el watcher de disponibilidad se dispare dos veces

- **watchDebounced (50ms)** para resetear disponibilidad
  - Agrupa múltiples cambios rápidos en una sola ejecución
  - Reduce actualizaciones innecesarias del DOM

## Impacto

- **INP estimado:** -10 a -20ms
- **Riesgo:** 🔴 ALTO - Afecta sincronización de campos del buscador

## Test plan

- [x] Cambiar ubicación de recogida → verificar que devolución se sincroniza
- [x] Cambiar fecha de recogida → verificar que devolución se actualiza (+7 días)
- [x] Cambiar hora de recogida → verificar que devolución se sincroniza
- [x] Hacer búsqueda completa y verificar que los resultados aparecen
- [x] Verificar animación del botón de búsqueda (aparece/desaparece correctamente)
- [x] Probar en móvil para confirmar mejora de INP