### PR TITLE
perf(lcp): optimizar LCP mobile moviendo preloads al head global

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -10,13 +10,9 @@ import { es } from '@nuxt/ui/locale'
 const toaster =  { expand: true, position: "top-center", duration: 10000 }
 useBaseSEO();
 
-// Critical CSS inline para prevenir FOUC + Resource hints para LCP
+// Critical CSS inline para prevenir FOUC
+// Preconnect movido a nuxt.config.ts para estar en HTML inicial
 useHead({
-  link: [
-    // Preconnect a Firebase Storage (mejora LCP ~200-400ms)
-    { rel: "preconnect", href: "https://firebasestorage.googleapis.com", crossorigin: "" },
-    { rel: "dns-prefetch", href: "https://firebasestorage.googleapis.com" },
-  ],
   style: [
     {
       key: "critical-fouc",

--- a/app/components/Images/Family.vue
+++ b/app/components/Images/Family.vue
@@ -3,6 +3,7 @@
     <source
       type="image/avif"
       media="(min-width: 768px)"
+      sizes="(min-width: 1280px) 50vw, (min-width: 768px) 45vw, 100vw"
       srcset="
         https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia.avif?alt=media&token=a14e3f1c-428e-40b2-ad1e-0d724579e487
       "
@@ -12,6 +13,7 @@
     <source
       type="image/avif"
       media="(max-width: 767px)"
+      sizes="100vw"
       srcset="
         https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia-movil.avif?alt=media&token=09ef76e8-4f99-4188-8d9a-57e13e198c4b
       "
@@ -22,6 +24,7 @@
     <source
       type="image/webp"
       media="(min-width: 768px)"
+      sizes="(min-width: 1280px) 50vw, (min-width: 768px) 45vw, 100vw"
       srcset="
         https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia.webp?alt=media&token=3a180793-69a9-471f-a1d1-8f720ba14662
       "
@@ -31,6 +34,7 @@
     <source
       type="image/webp"
       media="(max-width: 767px)"
+      sizes="100vw"
       srcset="
         https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia-movil.webp?alt=media&token=ba908a15-bfaa-4c82-88e4-538fee298fae
       "
@@ -41,6 +45,7 @@
     <source
       type="image/png"
       media="(min-width: 768px)"
+      sizes="(min-width: 1280px) 50vw, (min-width: 768px) 45vw, 100vw"
       srcset="
         https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia.png?alt=media&token=5b5675e2-3c7d-4076-b0e9-7bf74c085ef9
       "
@@ -50,6 +55,7 @@
     <source
       type="image/png"
       media="(max-width: 767px)"
+      sizes="100vw"
       srcset="
         https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia-movil.png?alt=media&token=769cd789-8e38-4cd8-b650-863a02dfa8ce
       "
@@ -60,6 +66,7 @@
     <img
       src="https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia.png?alt=media&token=5b5675e2-3c7d-4076-b0e9-7bf74c085ef9"
       alt="Familia disfrutando de un viaje en carro alquilado en Colombia"
+      sizes="(min-width: 1280px) 50vw, (min-width: 768px) 45vw, 100vw"
       width="2000"
       height="1620"
       loading="eager"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -307,20 +307,7 @@ useSchemaOrg([
 useHead({
   link: [
     { rel: "canonical", href: franchise.website },
-    {
-      rel: "preload",
-      as: "image",
-      href: "https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia.avif?alt=media&token=a14e3f1c-428e-40b2-ad1e-0d724579e487",
-      media: "(min-width: 768px)",
-      fetchpriority: "high",
-    },
-    {
-      rel: "preload",
-      as: "image",
-      href: "https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia-movil.avif?alt=media&token=09ef76e8-4f99-4188-8d9a-57e13e198c4b",
-      media: "(max-width: 767px)",
-      fetchpriority: "high",
-    },
+    // Preloads de imagen hero movidos a nuxt.config.ts para estar en HTML inicial
   ],
 });
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,6 +10,34 @@ export default defineNuxtConfig({
 
   modules: ['@nuxtjs/seo', '@nuxt/ui', '@pinia/nuxt', 'nuxt-llms'],
 
+  // Optimización LCP: preloads en HTML inicial (antes de JS)
+  app: {
+    head: {
+      link: [
+        // Preconnect a Firebase Storage (crítico para LCP)
+        { rel: 'preconnect', href: 'https://firebasestorage.googleapis.com', crossorigin: '' },
+        // Preload imagen hero mobile (LCP en móviles)
+        {
+          rel: 'preload',
+          as: 'image',
+          type: 'image/avif',
+          href: 'https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia-movil.avif?alt=media&token=09ef76e8-4f99-4188-8d9a-57e13e198c4b',
+          media: '(max-width: 767px)',
+          fetchpriority: 'high',
+        },
+        // Preload imagen hero desktop (LCP en escritorio)
+        {
+          rel: 'preload',
+          as: 'image',
+          type: 'image/avif',
+          href: 'https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Ffamilia.avif?alt=media&token=a14e3f1c-428e-40b2-ad1e-0d724579e487',
+          media: '(min-width: 768px)',
+          fetchpriority: 'high',
+        },
+      ],
+    },
+  },
+
   // Configuración SEO - controla cómo se generan los títulos
   site: {
     url: 'https://alquilatucarro.com',


### PR DESCRIPTION
## Summary
- Mueve preloads de imagen hero a `nuxt.config.ts` `app.head` para que estén en el HTML inicial (antes de JS)
- Mueve preconnect de Firebase Storage al config global
- Agrega atributo `sizes` a todas las fuentes del `<picture>` element

## Problema
LCP mobile: **4.5s** (target: <2.5s)

## Causa raíz
Los preloads estaban en `useHead()` de componentes Vue, ejecutándose después del HTML inicial. El navegador no podía iniciar el fetch de la imagen LCP hasta parsear el JavaScript.

## Solución
Mover preloads al `app.head` de `nuxt.config.ts` para que se incluyan directamente en el `<head>` del HTML renderizado por el servidor.

## Mejora esperada
**500-1000ms** de reducción en LCP mobile

## Test plan
- [ ] Verificar build exitoso
- [ ] Deploy a preview/producción  
- [ ] Medir LCP con PageSpeed Insights antes/después
- [ ] Confirmar que preloads aparecen en HTML inicial (View Source)