### PR TITLE
fix(middleware): redirigir fechas pasadas a mañana

### DIFF
--- a/app/middleware/validateSearchParams.ts
+++ b/app/middleware/validateSearchParams.ts
@@ -2,6 +2,7 @@ import {
   useStoreAdminData,
   createDateFromString,
   createTimeFromString,
+  createCurrentDateObject,
   isTimeObject,
   toDatetime,
   dayDifference
@@ -59,6 +60,26 @@ export default defineNuxtRouteMiddleware((to, from) => {
       }
     });
 
+  }
+
+  // Validación: fecha de recogida en el pasado
+  // Si el usuario accede con una URL que tiene fecha pasada (ej: link guardado, historial),
+  // redirige automáticamente a mañana con devolución +7 días para evitar errores.
+  // Impacto: bajo, solo afecta URLs con fechas inválidas.
+  const today = createCurrentDateObject();
+  if (dateFechaRecogida.compare(today) < 0) {
+    const tomorrow = today.add({ days: 1 });
+    const newReturnDate = tomorrow.add({ days: 7 });
+
+    to.params.fecha_recogida = tomorrow.toString();
+    to.params.fecha_devolucion = newReturnDate.toString();
+
+    return navigateTo({
+      name: to.name,
+      params: {
+        ...to.params
+      }
+    });
   }
 
   // Cuando la diferencia de fechas es mensual


### PR DESCRIPTION
## Summary
- Cuando usuarios acceden con URLs con fechas de recogida pasadas (links guardados, historial del navegador), el middleware ahora redirige a mañana con fecha de devolución +7 días en lugar de mostrar un error

## Changes
- `validateSearchParams.ts`: detectar fechas pasadas y redirigir automáticamente

## Test plan
- [x] Acceder con fecha de recogida pasada redirige a mañana
- [x] Fecha de devolución se establece a +7 días desde mañana
- [x] URLs con fechas válidas funcionan normalmente