### PR TITLE
fix(cls): eliminar layout shifts en testimonios y blog

### DIFF
--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -26,11 +26,11 @@
             class="block group"
           >
             <article class="bg-white rounded-xl shadow-md overflow-hidden md:flex hover:shadow-xl transition-shadow duration-300">
-              <div class="md:w-1/2">
+              <div class="md:w-1/2 aspect-video md:aspect-auto overflow-hidden">
                 <img
                   :src="featuredPost.image"
                   :alt="featuredPost.alt"
-                  class="w-full h-64 md:h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                  class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                   loading="eager"
                 >
               </div>
@@ -89,12 +89,12 @@
             :to="post.path"
             class="group"
           >
-            <article class="bg-white rounded-xl shadow-sm overflow-hidden hover:shadow-lg hover:-translate-y-1 transition-all duration-200 h-full flex flex-col">
-              <div class="relative overflow-hidden">
+            <article class="bg-white rounded-xl shadow-sm overflow-hidden hover:shadow-lg transition-shadow duration-200 h-full flex flex-col">
+              <div class="relative overflow-hidden aspect-video">
                 <img
                   :src="post.image"
                   :alt="post.alt"
-                  class="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+                  class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
                   loading="lazy"
                 >
                 <span class="absolute top-3 left-3 inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold text-white bg-red-700 rounded-full">

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -216,7 +216,7 @@
           <div
             v-for="testimonio in testimonios"
             :key="testimonio.user.name"
-            class="border border-gray-100 rounded-lg bg-gray-50 shadow-sm p-5 md:p-6 hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+            class="border border-gray-100 rounded-lg bg-gray-50 shadow-sm p-5 md:p-6 hover:shadow-lg transition-shadow duration-200"
           >
             <UUser
               size="3xl"


### PR DESCRIPTION
## Summary
Corrige problemas de CLS (Cumulative Layout Shift) identificados en desktop.

## Cambios

### Testimonios (index.vue)
- ❌ `hover:-translate-y-1` → ✅ Solo `hover:shadow-lg`
- El `translate` movía el elemento, causando layout shift

### Blog Featured (blog/index.vue)
- ❌ `h-64 md:h-full` → ✅ `aspect-video md:aspect-auto`
- Reserva espacio para la imagen antes de cargar

### Blog Grid Cards (blog/index.vue)
- ❌ `hover:-translate-y-1` → ✅ Solo `hover:shadow-lg`
- ❌ `h-48` → ✅ `aspect-video`
- Elimina shift en hover y reserva espacio para imágenes

## Impacto esperado
- CLS debería bajar de 1.000 a < 0.1 (meta: "bueno")
- Las transiciones de hover ahora solo afectan shadow (no layout)
- Las imágenes ya no causan reflow al cargar

## Test plan
- [ ] Verificar que testimonios no "saltan" al hacer hover
- [ ] Verificar que blog images no causan reflow
- [ ] Re-test en PageSpeed Insights desktop