### PR TITLE
SEO: Optimizar H2s, word count y Product Schema para 19 ciudades

### DIFF
--- a/app/components/CityPage.vue
+++ b/app/components/CityPage.vue
@@ -373,6 +373,7 @@ import {
 } from "#components";
 import { useCityExpandedContent, hasCityExpandedContent } from "~/composables/useCityContent";
 import { useRelatedCities } from "~/composables/useCityRelations";
+import { useCityProductSchema } from "~/composables/useCityProductSchema";
 
 /** stores */
 const storeSearch = useStoreSearchData();
@@ -411,6 +412,11 @@ const relatedCities = props.city?.id ? useRelatedCities(props.city.id) : [];
 // Add AggregateRating schema for city-specific testimonials (shows stars in Google SERPs)
 if (props.city?.name && testimonios) {
   useCityAggregateRating(props.city.name, testimonios)
+}
+
+// Add Product Schema for SEO (shows vehicle offers in Google SERPs)
+if (props.city?.name && props.city?.id) {
+  useCityProductSchema(props.city.name, props.city.id)
 }
 
 // Get city-specific FAQs for UI display

--- a/app/composables/useCityProductSchema.ts
+++ b/app/composables/useCityProductSchema.ts
@@ -1,0 +1,118 @@
+import type { Product, AggregateOffer } from 'schema-dts'
+
+interface CityPricing {
+  lowPrice: number
+  highPrice: number
+}
+
+// Base prices per city (in COP) - from useCityFAQs.ts
+const cityPricing: Record<string, CityPricing> = {
+  'Bogotá': { lowPrice: 110000, highPrice: 450000 },
+  'Medellín': { lowPrice: 115000, highPrice: 460000 },
+  'Cali': { lowPrice: 105000, highPrice: 420000 },
+  'Cartagena': { lowPrice: 120000, highPrice: 480000 },
+  'Barranquilla': { lowPrice: 100000, highPrice: 400000 },
+  'Santa Marta': { lowPrice: 110000, highPrice: 440000 },
+  'Pereira': { lowPrice: 105000, highPrice: 420000 },
+  'Bucaramanga': { lowPrice: 100000, highPrice: 400000 },
+  'Armenia': { lowPrice: 100000, highPrice: 400000 },
+  'Manizales': { lowPrice: 105000, highPrice: 420000 },
+  'Villavicencio': { lowPrice: 95000, highPrice: 380000 },
+  'Valledupar': { lowPrice: 95000, highPrice: 380000 },
+  'Ibagué': { lowPrice: 95000, highPrice: 380000 },
+  'Neiva': { lowPrice: 90000, highPrice: 360000 },
+  'Cúcuta': { lowPrice: 90000, highPrice: 360000 },
+  'Montería': { lowPrice: 95000, highPrice: 380000 },
+  'Floridablanca': { lowPrice: 95000, highPrice: 380000 },
+  'Palmira': { lowPrice: 100000, highPrice: 400000 },
+  'Soledad': { lowPrice: 95000, highPrice: 380000 },
+}
+
+// Representative vehicle categories for schema
+const representativeCategories = [
+  {
+    code: 'C',
+    name: 'Económico',
+    description: 'Vehículos compactos perfectos para ciudad. Fiat Mobi, Kia Picanto, Renault Kwid.',
+    image: 'https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Fcategorias%2Fgamac%2Fgrupo-c-kia-picanto-alquiler-de-carros.avif?alt=media',
+    priceMultiplier: 1.0
+  },
+  {
+    code: 'FX',
+    name: 'Sedán Automático',
+    description: 'Sedanes cómodos con transmisión automática. Kia Rio, Hyundai Accent, Suzuki Dzire.',
+    image: 'https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Fcategorias%2Fgrupofx%2Fgrupo-fx-kia-rio-alquiler-de-carros.avif?alt=media',
+    priceMultiplier: 1.3
+  },
+  {
+    code: 'GC',
+    name: 'Camioneta SUV',
+    description: 'Camionetas compactas ideales para familias. Suzuki Vitara, Hyundai Creta, Fiat Pulse.',
+    image: 'https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Fcategorias%2Fgrupogc%2Fgrupo-gc-suzuki-vitara-at-alquiler-de-camionetas.avif?alt=media',
+    priceMultiplier: 1.8
+  },
+  {
+    code: 'LE',
+    name: 'Camioneta Premium',
+    description: 'SUVs de lujo con todas las comodidades. Kia Sportage, Hyundai Tucson, Renault Koleos.',
+    image: 'https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Fcategorias%2Fgrupole%2Fgrupo-le-kia-sportage-alquiler-de-camionetas.avif?alt=media',
+    priceMultiplier: 2.5
+  }
+]
+
+/**
+ * Generates Product Schema for city landing pages
+ * This provides structured data for Google to show rich results
+ * even when no search has been performed
+ */
+export function useCityProductSchema(cityName: string, citySlug: string) {
+  const { franchise } = useAppConfig()
+
+  const pricing = cityPricing[cityName] || { lowPrice: 100000, highPrice: 400000 }
+
+  const productSchemas = representativeCategories.map((category) => {
+    const categoryLowPrice = Math.round(pricing.lowPrice * category.priceMultiplier)
+    const categoryHighPrice = Math.round(pricing.highPrice * category.priceMultiplier)
+
+    return <Product>{
+      '@type': 'Product',
+      '@id': `${franchise.website}/${citySlug}#vehicle-${category.code}`,
+      name: `Alquiler ${category.name} en ${cityName}`,
+      description: `${category.description} Disponible para alquiler en ${cityName}, Colombia.`,
+      category: 'Alquiler de Vehículos',
+      brand: {
+        '@type': 'Brand',
+        name: 'Alquilatucarro'
+      },
+      image: category.image,
+      offers: <AggregateOffer>{
+        '@type': 'AggregateOffer',
+        priceCurrency: 'COP',
+        lowPrice: categoryLowPrice,
+        highPrice: categoryHighPrice,
+        offerCount: 4,
+        availability: 'https://schema.org/InStock',
+        priceValidUntil: '2026-12-31',
+        seller: {
+          '@type': 'Organization',
+          name: 'Alquilatucarro',
+          url: franchise.website
+        },
+        areaServed: {
+          '@type': 'City',
+          name: cityName,
+          containedInPlace: {
+            '@type': 'Country',
+            name: 'Colombia'
+          }
+        }
+      }
+    }
+  })
+
+  useSchemaOrg(productSchemas)
+
+  return {
+    productSchemas
+  }
+}


### PR DESCRIPTION
## Summary

- **H2s con keywords**: 8/8 H2s ahora incluyen variaciones de "alquiler de carros" (antes 1/8)
- **Word count**: Nueva sección "Ventajas de alquilar carro" añade ~100 palabras (~770 total, meta 800+)
- **Product Schema**: Nuevo composable genera schema de productos representativos para las 19 ciudades

## Cambios

### `CityPage.vue`
- 7 H2s modificados con keywords SEO
- Nueva sección de ventajas con 4 beneficios (precios, flota, entrega, atención)
- Integración de `useCityProductSchema`

### `useCityProductSchema.ts` (nuevo)
- 4 categorías representativas (Económico, Sedán, SUV, Premium)
- Precios específicos por ciudad (desde FAQs existentes)
- Schema.org Product con AggregateOffer

## Test plan

- [ ] Verificar que las páginas de ciudad renderizan correctamente
- [ ] Validar schema con Google Rich Results Test
- [ ] Confirmar que no hay errores de hidratación en consola