### PR TITLE
fix(cls): add aspect-ratio containers for lazy images and fix star sizing

### DIFF
--- a/app/components/CityPage.vue
+++ b/app/components/CityPage.vue
@@ -352,7 +352,7 @@
             </UUser>
             <p class="mt-4 text-gray-700">{{ testimonio.quote }}</p>
             <div class="flex flex-row space-x-2 mt-4">
-              <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="text-yellow-500 size-6" />
+              <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="text-yellow-500 w-5 h-5" />
             </div>
           </div>
         </div>

--- a/app/components/Icons/StarIcon.vue
+++ b/app/components/Icons/StarIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="16" height="16">
+  <svg xmlns="http://www.w3.org/2000/svg" :class="cls" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
   </svg>
 </template>

--- a/app/components/Images/Categorias/Compacto.vue
+++ b/app/components/Images/Categorias/Compacto.vue
@@ -64,7 +64,7 @@
       width="800"
       height="300"
       loading="lazy"
-      class="mx-auto"
+      class="mx-auto w-full h-full object-contain"
     />
   </picture>
 </template>

--- a/app/components/Images/Categorias/SUV.vue
+++ b/app/components/Images/Categorias/SUV.vue
@@ -64,7 +64,7 @@
       width="800"
       height="300"
       loading="lazy"
-      class="mx-auto"
+      class="mx-auto w-full h-full object-contain"
     />
   </picture>
 </template>

--- a/app/components/Images/Categorias/Sedan.vue
+++ b/app/components/Images/Categorias/Sedan.vue
@@ -64,7 +64,7 @@
       width="800"
       height="300"
       loading="lazy"
-      class="mx-auto"
+      class="mx-auto w-full h-full object-contain"
     />
   </picture>
 </template>

--- a/app/components/Images/Persona.vue
+++ b/app/components/Images/Persona.vue
@@ -67,7 +67,7 @@
       width="2000"
       height="1620"
       loading="lazy"
-      class="mx-auto"
+      class="mx-auto w-full h-full object-contain"
     />
   </picture>
 </template>

--- a/app/components/Images/Video.vue
+++ b/app/components/Images/Video.vue
@@ -68,7 +68,7 @@
       width="2000"
       height="1620"
       loading="lazy"
-      class="mx-auto cursor-pointer"
+      class="mx-auto w-full h-full object-contain cursor-pointer"
     />
   </picture>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -46,7 +46,10 @@
         </div>
       </template>
       <template #default>
-        <LazyImagesVideo hydrate-on-visible />
+        <!-- CLS fix: reservar espacio con aspect-ratio antes de que cargue la imagen -->
+        <div class="w-full aspect-[100/81]">
+          <LazyImagesVideo hydrate-on-visible />
+        </div>
       </template>
     </UPageSection>
 
@@ -101,7 +104,10 @@
         </div>
       </template>
       <template #default>
-        <LazyImagesPersona hydrate-on-visible />
+        <!-- CLS fix: reservar espacio con aspect-ratio antes de que cargue la imagen -->
+        <div class="w-full aspect-[100/81]">
+          <LazyImagesPersona hydrate-on-visible />
+        </div>
       </template>
     </UPageSection>
 
@@ -132,7 +138,10 @@
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-4 md:mt-0">
           <!-- Compacto -->
           <div class="flex flex-col items-center text-center">
-            <LazyImagesCategoriasCompacto hydrate-on-visible />
+            <!-- CLS fix: reservar espacio con aspect-ratio (800x300) -->
+            <div class="w-full aspect-[8/3]">
+              <LazyImagesCategoriasCompacto hydrate-on-visible />
+            </div>
             <h3 class="font-bold text-black text-lg mt-0">COMPACTO</h3>
             <p class="text-black mt-2">Practicidad urbana con estilo. La agilidad que necesitas en la ciudad</p>
             <LazyUModal hydrate-on-interaction class="mt-4" :ui="{ content: 'bg-white', close: 'bg-black text-white rounded-full' }">
@@ -149,7 +158,10 @@
           </div>
           <!-- Sedan -->
           <div class="flex flex-col items-center text-center">
-            <LazyImagesCategoriasSedan hydrate-on-visible />
+            <!-- CLS fix: reservar espacio con aspect-ratio (800x300) -->
+            <div class="w-full aspect-[8/3]">
+              <LazyImagesCategoriasSedan hydrate-on-visible />
+            </div>
             <h3 class="font-bold text-black text-lg mt-0">SEDAN</h3>
             <p class="text-black mt-2">Confort y espacio. Disfruta cada viaje con la máxima comodidad</p>
             <LazyUModal hydrate-on-interaction class="mt-4" :ui="{ content: 'bg-white', close: 'bg-black text-white rounded-full' }">
@@ -166,7 +178,10 @@
           </div>
           <!-- Camioneta -->
           <div class="flex flex-col items-center text-center">
-            <LazyImagesCategoriasSUV hydrate-on-visible />
+            <!-- CLS fix: reservar espacio con aspect-ratio (800x300) -->
+            <div class="w-full aspect-[8/3]">
+              <LazyImagesCategoriasSUV hydrate-on-visible />
+            </div>
             <h3 class="font-bold text-black text-lg mt-0">CAMIONETA</h3>
             <p class="text-black mt-2">Robustez y tamaño. Capacidad para dominar cualquier camino</p>
             <LazyUModal hydrate-on-interaction class="mt-4" :ui="{ content: 'bg-white', close: 'bg-black text-white rounded-full' }">
@@ -210,7 +225,7 @@
             </div>
             <p class="mt-4 text-gray-700">{{ testimonio.quote }}</p>
             <div class="flex flex-row mt-4">
-              <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="text-yellow-500 size-6" />
+              <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="text-yellow-500 w-5 h-5" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add aspect-ratio containers around lazy-loaded images to prevent CLS (1.004 → expected ~0.1)
- Fix star icons sizing: size-6 (24px) → w-5 h-5 (20px)
- Remove conflicting hardcoded dimensions from StarIcon SVG

## Changes
| File | Change |
|------|--------|
| index.vue | Aspect-ratio wrappers for Video, Persona, Categories |
| StarIcon.vue | Remove width/height attributes |
| CityPage.vue | Star sizing consistency |
| Image components | Add w-full h-full object-contain |

## Test plan
- [ ] Verify stars display at correct size on index and city pages
- [ ] Run Lighthouse/PageSpeed to confirm CLS improvement
- [ ] Check lazy images load without layout shift