### PR TITLE
fix(hydration): add missing :key to v-for directives

### DIFF
--- a/app/components/CategorySelectionSection.vue
+++ b/app/components/CategorySelectionSection.vue
@@ -20,26 +20,21 @@
       </div>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-      <template v-for="category in filteredCategories">
-        <template
+      <template v-for="category in filteredCategories" :key="`cat-${category.categoryCode}`">
+        <placeholders-unable-category-card
           v-if="
             category.estimatedTotalAmount == 999999999 &&
             vehicleCategories[category.categoryCode]
           "
-        >
-          <placeholders-unable-category-card
-            :category
-            :vehicleCategory="vehicleCategories[category.categoryCode]"
-          />
-        </template>
-        <template v-else-if="vehicleCategories[category.categoryCode]">
-          <category-card
-            :category
-            :vehicle-category="vehicleCategories[category.categoryCode]"
-            :key="`category-${category.categoryCode}`"
-            @selected-category="setSelectedCategory"
-          />
-        </template>
+          :category
+          :vehicleCategory="vehicleCategories[category.categoryCode]"
+        />
+        <category-card
+          v-else-if="vehicleCategories[category.categoryCode]"
+          :category
+          :vehicle-category="vehicleCategories[category.categoryCode]"
+          @selected-category="setSelectedCategory"
+        />
       </template>
     </div>
     <u-slideover

--- a/app/components/CityPage.vue
+++ b/app/components/CityPage.vue
@@ -9,7 +9,7 @@
         <div
           class="flex flex-row space-x-0.5 text-white text-center justify-center items-center text-sm"
         >
-          <StarIcon v-for="i in [1,2,3,4,5]" cls="w-2.5 h-2.5 md:w-4 md:h-4" />
+          <StarIcon v-for="i in [1,2,3,4,5]" :key="i" cls="w-2.5 h-2.5 md:w-4 md:h-4" />
           <span class="ml-2">4.9 reviews</span>
         </div>
       </template>

--- a/app/components/SelectBranch.vue
+++ b/app/components/SelectBranch.vue
@@ -15,6 +15,7 @@
         <option value="null">Elige una ciudad</option>
         <option
           v-for="branch in branches"
+          :key="branch.code"
           :value="branch.code"
           v-text="branch.name"
         ></option>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -78,6 +78,7 @@
         <div class="flex flex-col md:flex-row md:flex-wrap justify-center gap-1 md:gap-3">
           <UButton
             v-for="city in cities"
+            :key="city.id"
             :to="getCityReservationURL(city)"
             :external="true"
             target="_blank"
@@ -93,7 +94,7 @@
     <section class="bg-[#000073] text-white py-8 lg:py-6">
       <div class="max-w-7xl mx-auto px-4">
         <div class="flex flex-col md:flex-row items-center justify-center gap-2 md:gap-4">
-          <template v-for="(footerLink, index) in franchise.footerLinks">
+          <template v-for="(footerLink, index) in franchise.footerLinks" :key="`footer-${index}`">
             <NuxtLink
               :to="footerLink.link"
               class="underline hover:no-underline"


### PR DESCRIPTION
## Summary
- Fixes "Hydration completed but contains mismatches" warning on city pages
- Adds required `:key` attributes to all v-for loops missing them
- Simplifies nested template structure in CategorySelectionSection.vue

## Files Changed
- `CityPage.vue`: Added `:key="i"` to StarIcon loop
- `CategorySelectionSection.vue`: Added `:key` to categories template, simplified structure
- `SelectBranch.vue`: Added `:key="branch.code"` to options loop
- `default.vue`: Added `:key="city.id"` and `:key="`footer-${index}`"` to loops

## Test plan
- [ ] Navigate to a city page (e.g., /bogota)
- [ ] Open browser console
- [ ] Verify no hydration mismatch warnings appear
- [ ] Test mobile and desktop views