### PR TITLE
fix(a11y): improve form accessibility and contrast

### DIFF
--- a/app/components/CityPage.vue
+++ b/app/components/CityPage.vue
@@ -219,7 +219,7 @@
             >
               <div class="flex items-start justify-between mb-3">
                 <h3 class="text-xl font-bold text-gray-900">{{ destination.name }}</h3>
-                <span class="text-sm font-medium text-red-600 bg-red-50 px-3 py-1 rounded-full whitespace-nowrap">
+                <span class="text-sm font-medium text-gray-700 bg-gray-100 px-3 py-1 rounded-full whitespace-nowrap">
                   {{ destination.time }}
                 </span>
               </div>

--- a/app/components/ReservationForm.vue
+++ b/app/components/ReservationForm.vue
@@ -7,48 +7,53 @@
     class="scheme-dark"
   >
       <div class="grid grid-cols-2 gap-2">
-        <u-form-field name="nombreCompleto">
+        <u-form-field name="nombreCompleto" label="Nombres">
           <u-input
             v-model="formState.nombreCompleto"
             class="w-full"
             placeholder="Nombres*"
+            aria-label="Nombres"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field name="apellidos">
+        <u-form-field name="apellidos" label="Apellidos">
           <u-input
             v-model="formState.apellidos"
             class="w-full"
             placeholder="Apellidos*"
+            aria-label="Apellidos"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field name="tipoIdentificacion">
+        <u-form-field name="tipoIdentificacion" label="Tipo de identificación">
           <u-select
             v-model="formState.tipoIdentificacion"
             class="w-full"
             placeholder="ID Tipo*"
+            aria-label="Tipo de identificación"
             :items="identificationTypeOptions"
             :ui="selectUi"
           ></u-select>
         </u-form-field>
-        <u-form-field name="identificacion">
+        <u-form-field name="identificacion" label="Número de identificación">
           <u-input
             v-model="formState.identificacion"
             class="w-full"
             placeholder="ID Número*"
+            aria-label="Número de identificación"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field class="col-span-2" name="email">
+        <u-form-field class="col-span-2" name="email" label="Correo electrónico">
           <u-input
             v-model="formState.email"
             class="w-full"
             placeholder="Email*"
+            aria-label="Correo electrónico"
             :ui="inputUi"
           ></u-input>
         </u-form-field>
-        <u-form-field class="col-span-2" name="telefono">
+        <u-form-field class="col-span-2" name="telefono" label="Teléfono">
           <VueTelInput
             v-model="formState.telefono"
             mode="international"

--- a/app/components/Searcher.vue
+++ b/app/components/Searcher.vue
@@ -9,15 +9,17 @@
                     v-if="lugarRecogida"
                     id="pickup-location-mobile"
                     v-model="lugarRecogida"
+                    aria-label="Lugar de recogida"
                     class="w-full sm:hidden"
                 >
                     <option
                         v-for="branch in sortedBranches"
+                        :key="branch.code"
                         v-text="branch.name"
                         :value="branch.code"
                     ></option>
                 </select>
-                <select v-else disabled class="w-full sm:hidden text-gray-400">
+                <select v-else disabled class="w-full sm:hidden text-gray-400" aria-label="Lugar de recogida">
                     <option>Cargando...</option>
                 </select>
                 <!-- Desktop: u-select-menu (CSS: hidden sm:block) -->
@@ -51,15 +53,17 @@
                     v-if="lugarDevolucion"
                     id="return-location-mobile"
                     v-model="lugarDevolucion"
+                    aria-label="Lugar de devolución"
                     class="w-full sm:hidden"
                 >
                     <option
                         v-for="branch in sortedBranches"
+                        :key="branch.code"
                         v-text="branch.name"
                         :value="branch.code"
                     ></option>
                 </select>
-                <select v-else disabled class="w-full sm:hidden text-gray-400">
+                <select v-else disabled class="w-full sm:hidden text-gray-400" aria-label="Lugar de devolución">
                     <option>Cargando...</option>
                 </select>
                 <!-- Desktop: u-select-menu (CSS: hidden sm:block) -->
@@ -91,8 +95,10 @@
                 <!-- Móvil: input nativo (CSS: sm:hidden) -->
                 <input
                     type="date"
+                    id="pickup-date-mobile"
                     name="pickup-date-mobile"
                     v-model="selectedPickupDate"
+                    aria-label="Día de recogida"
                     class="w-full sm:hidden"
                     :min="minPickupDate.toString()"
                 >
@@ -139,8 +145,10 @@
                 <!-- Móvil: input nativo (CSS: sm:hidden) -->
                 <input
                     type="date"
+                    id="return-date-mobile"
                     name="return-date-mobile"
                     v-model="selectedReturnDate"
+                    aria-label="Día de devolución"
                     class="w-full sm:hidden"
                     :min="minPickupDate.toString()"
                     :max="maxReturnDate?.toString()"
@@ -191,10 +199,12 @@
                 <select
                     id="pickup-hour-mobile"
                     v-model="horaRecogida"
+                    aria-label="Hora de recogida"
                     class="w-full sm:hidden"
                 >
                     <option
                         v-for="hour in pickupHourOptions"
+                        :key="hour.value"
                         v-text="hour.label"
                         :value="hour.value"
                     ></option>
@@ -221,10 +231,12 @@
                 <select
                     id="return-hour-mobile"
                     v-model="horaDevolucion"
+                    aria-label="Hora de devolución"
                     class="w-full sm:hidden"
                 >
                     <option
                         v-for="hour in returnHourOptions"
+                        :key="hour.value"
                         v-text="hour.label"
                         :value="hour.value"
                     ></option>

--- a/app/composables/usePhoneField.ts
+++ b/app/composables/usePhoneField.ts
@@ -7,6 +7,7 @@ export default function usePhoneField() {
       id: "telefono",
       name: "telefono",
       placeholder: "Whatsapp o Teléfono Móvil*",
+      'aria-label': "Número de teléfono",
     }));
 
     const phoneDropdownOptions = {


### PR DESCRIPTION
## Summary
- Add `aria-label` attributes to native form elements (selects, inputs) in Searcher.vue
- Add `label` props to `u-form-field` components in ReservationForm.vue
- Add `aria-label` to phone input in usePhoneField.ts
- Fix low contrast: change `text-red-600 bg-red-50` to `text-gray-700 bg-gray-100` in CityPage.vue

## Why
Form elements without associated labels cause accessibility issues for screen readers. The red text on red background had insufficient contrast ratio.

## Test plan
- [ ] Verify screen readers announce form field names correctly
- [x] Check contrast ratio meets WCAG AA standards
- [ ] Test reservation form on city pages