### PR TITLE
fix(cls): add critical CSS for star icon sizes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,8 @@ export default defineNuxtConfig({
             svg { max-width: 100%; height: auto; }
             header svg { max-height: 3.5rem !important; max-width: 10rem !important; }
             .w-2\\.5 { width: 0.625rem; } .h-2\\.5 { height: 0.625rem; }
+            .w-4 { width: 1rem; } .h-4 { height: 1rem; }
+            .w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
             .mx-auto { margin-left: auto; margin-right: auto; }
             @media (min-width: 768px) { header .md\\:hidden { display: none !important; } }
             @media (max-width: 767px) { header .hidden { display: none !important; } }


### PR DESCRIPTION
## Summary
- Add `.w-4`, `.h-4`, `.w-5`, `.h-5` classes to critical CSS in `nuxt.config.ts`
- Prevents star icon FOUC (giant stars flash) on city pages during initial render

## Root Cause
The existing critical CSS rule `svg { height: auto }` overrides SVG `width`/`height` attributes. Without the Tailwind size classes in critical CSS, stars render at container size until full CSS loads.

## Test plan
- [ ] Load `/bogota` in incognito mode
- [ ] Verify stars don't appear giant during initial load
- [ ] Check other city pages for consistent behavior