### PR TITLE
fix(seo): resolve CLS star icons, duplicate H1, and ALQUILERDE FOUC

### DIFF
--- a/app/components/CityPage.vue
+++ b/app/components/CityPage.vue
@@ -14,7 +14,8 @@
         </div>
       </template>
       <template #title>
-        <h1 class="text-white text-center uppercase font-bold" style="letter-spacing: -0.025em;">
+        <!-- UPageHero ya renderiza <h1> para slot #title, usamos div para evitar h1 duplicado -->
+        <div class="text-white text-center uppercase font-bold" style="letter-spacing: -0.025em;">
           <span class="block text-2xl md:text-3xl lg:text-4xl" style="letter-spacing: -0.025em;">
             <span class="block" style="letter-spacing: -0.025em;">ALQUILER</span>
             <span class="block" style="letter-spacing: -0.025em;">DE CARROS EN</span>
@@ -25,7 +26,7 @@
             <LocationIcon cls="text-red-600 size-8 md:size-10 lg:size-14 translate-y-1" />
           </span>
           <span class="block text-2xl md:text-3xl lg:text-4xl text-white colombia-sweep" style="letter-spacing: 0.025em;">Colombia</span>
-        </h1>
+        </div>
       </template>
       <template #body>
         <!-- Solo visible en mobile -->

--- a/app/components/Hero/Headline.server.vue
+++ b/app/components/Hero/Headline.server.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-row items-center justify-center space-x-0.5 text-white text-center">
-    <svg v-for="i in 5" :key="i" xmlns="http://www.w3.org/2000/svg" class="w-2.5 h-2.5 md:w-4 md:h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <svg v-for="i in 5" :key="i" xmlns="http://www.w3.org/2000/svg" width="10" height="10" class="w-2.5 h-2.5 md:w-4 md:h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/>
     </svg>
     <span class="ml-2 text-xs md:text-base">4.9 reviews</span>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,9 +30,11 @@ export default defineNuxtConfig({
             .w-2\\.5 { width: 0.625rem; } .h-2\\.5 { height: 0.625rem; }
             .w-4 { width: 1rem; } .h-4 { height: 1rem; }
             .w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
+            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } }
             .mx-auto { margin-left: auto; margin-right: auto; }
             @media (min-width: 768px) { header .md\\:hidden { display: none !important; } }
             @media (max-width: 767px) { header .hidden { display: none !important; } }
+            .block { display: block; }
             .bg-white { background-color: #fff; }
             .text-white { color: #fff; }
             .text-black { color: #000; }


### PR DESCRIPTION
## Summary
- Add critical CSS for responsive star icon variants (`md:w-4`, `md:h-4`) to fix CLS on city pages
- Fix duplicate H1: UPageHero already renders `<h1>` for `#title` slot - changed inner `<h1>` to `<div>` in CityPage.vue
- Add `.block { display: block; }` to critical CSS to prevent "ALQUILERDE" text collapse during FOUC

## Root cause analysis
1. **Star CLS**: PR #43 added CSS for `.w-5/.h-5` but city page stars use `md:w-4 md:h-4` responsive variants
2. **Duplicate H1**: UPageHero component (line 46) wraps `#title` slot content in `<h1>`, and CityPage.vue added another `<h1>` inside
3. **ALQUILERDE**: Text "ALQUILER" and "DE CARROS" in separate `<span class="block">` elements collapse before CSS loads

## Test plan
- [ ] Check PageSpeed Insights CLS score on city pages (target: < 0.1)
- [ ] Verify single H1 in DOM on city pages
- [ ] Verify "ALQUILER DE CARROS EN" renders correctly without collapse