### PR TITLE
feat(seo): add www to non-www canonical redirect

### DIFF
--- a/server/middleware/canonical-redirect.ts
+++ b/server/middleware/canonical-redirect.ts
@@ -1,0 +1,20 @@
+/**
+ * Server middleware: Redirect www → non-www (canonical domain)
+ *
+ * SEO rationale: Google Search Console shows traffic split between
+ * www.alquilatucarro.com and alquilatucarro.com. This consolidates
+ * all traffic to the canonical non-www domain with a 301 redirect.
+ */
+export default defineEventHandler((event) => {
+  const host = getRequestHost(event, { xForwardedHost: true })
+
+  // Only redirect if host starts with www
+  if (host?.startsWith('www.')) {
+    const canonicalHost = host.replace(/^www\./, '')
+    const url = getRequestURL(event)
+    const canonicalUrl = `https://${canonicalHost}${url.pathname}${url.search}`
+
+    // 301 permanent redirect for SEO
+    return sendRedirect(event, canonicalUrl, 301)
+  }
+})


### PR DESCRIPTION
## Summary
- Agrega server middleware que redirige `www.alquilatucarro.com` → `alquilatucarro.com`
- Usa redirect 301 (permanente) para consolidar señales SEO

## Contexto
GSC mostró tráfico dividido:
| Dominio | Clics | Impresiones |
|---------|-------|-------------|
| alquilatucarro.com | 323 | 14,802 |
| www.alquilatucarro.com | 72 | 3,163 |

Este redirect consolida todo el tráfico y link equity en el dominio canónico.

## Archivo agregado
- `server/middleware/canonical-redirect.ts`

## Test plan
- [ ] Visitar https://www.alquilatucarro.com y verificar redirect a https://alquilatucarro.com
- [ ] Verificar que el redirect es 301 (permanente)
- [ ] Verificar que paths y query strings se preservan (ej: www.alquilatucarro.com/bogota → alquilatucarro.com/bogota)