### PR TITLE
fix(cls): use innerHTML instead of children for critical CSS

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,8 @@ export default defineNuxtConfig({
       // CSS crítico - balance entre tamaño y prevención de FOUC
       style: [
         {
-          children: `
+          key: 'critical-cls',
+          innerHTML: `
             *, *::before, *::after { box-sizing: border-box; }
             body { margin: 0; font-family: system-ui, -apple-system, sans-serif; }
             img { max-width: 100%; height: auto; display: block; }


### PR DESCRIPTION
## Summary
- Fix critical CSS not being rendered in HTML output
- Change `children` to `innerHTML` in nuxt.config.ts app.head.style

## Root Cause Analysis
The critical CSS added in PR #47 was **never being rendered** because:
1. `nuxt.config.ts` used `children: "..."` property
2. Nuxt 3 / unhead requires `innerHTML: "..."` for inline styles
3. The CSS was defined but silently ignored

Evidence from browser inspection:
- `hasNuxtConfigCSS: false` - None of the inline styles contained the critical CSS
- `app.vue` uses `innerHTML` and works correctly
- `nuxt.config.ts` used `children` and was NOT working

## Expected Impact
Desktop CLS should improve from 1.0 to near 0, as the grid and aspect-ratio CSS will now be included in the initial HTML.

## Test plan
- [ ] Merge and wait for deploy (~5 min)
- [ ] Run PageSpeed Insights on Desktop
- [ ] Verify critical CSS is present in HTML source
- [ ] Confirm CLS improvement