### PR TITLE
fix(cls): add star rating text critical CSS classes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -33,7 +33,7 @@ export default defineNuxtConfig({
             .w-2\\.5 { width: 0.625rem; } .h-2\\.5 { height: 0.625rem; }
             .w-4 { width: 1rem; } .h-4 { height: 1rem; }
             .w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
-            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } }
+            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } .md\\:text-base { font-size: 1rem; line-height: 1.5rem; } }
             .mx-auto { margin-left: auto; margin-right: auto; }
             @media (min-width: 768px) { header .md\\:hidden { display: none !important; } }
             @media (max-width: 767px) { header .hidden { display: none !important; } }
@@ -77,6 +77,9 @@ export default defineNuxtConfig({
             .justify-center { justify-content: center; }
             .flex-row { flex-direction: row; }
             .space-x-0\\.5 > :not(:last-child) { margin-right: 0.125rem; }
+            /* Star rating text - CRÍTICO para CLS */
+            .ml-2 { margin-left: 0.5rem; }
+            .text-xs { font-size: 0.75rem; line-height: 1rem; }
             /* Max-width container */
             .max-w-\\(--ui-container\\), .max-w-7xl { max-width: 80rem; }
             @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- Add missing CSS classes for Hero/Headline.server.vue component star rating text
- Classes added: `ml-2`, `text-xs`, `md:text-base`
- These classes were causing CLS when deferred stylesheet loaded

## Root Cause Analysis
The `Hero/Headline.server.vue` component (Nuxt Islands) has CSS classes that were NOT in critical CSS:

```vue
<span class="ml-2 text-xs md:text-base">4.9 reviews</span>
```

When the deferred stylesheet loads:
1. `ml-2` adds 8px margin-left
2. `text-xs` changes font-size
3. These changes cause layout shift

## Changes
Added to `nuxt.config.ts` critical CSS:
```css
.ml-2 { margin-left: 0.5rem; }
.text-xs { font-size: 0.75rem; line-height: 1rem; }
@media (min-width: 768px) {
  .md\:text-base { font-size: 1rem; line-height: 1.5rem; }
}
```

## Test Plan
- [ ] Run PageSpeed Insights on https://alquilatucarro.com
- [ ] Verify CLS improved from current 0.21
- [ ] Check star rating text displays correctly on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)