### PR TITLE
fix(seo): add 301 redirects for GSC 404 errors

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -262,7 +262,10 @@ export default defineNuxtConfig({
         headers: {
           'Cache-Control': 'public, max-age=3600'
         }
-      }
+      },
+      // Redirects para URLs legacy (404s en Google Search Console)
+      '/gana/politicas-privacidad.html': { redirect: '/gana/politicas-privacidad', statusCode: 301 },
+      '/tratamiento-datos-alquilatucarro.pdf': { redirect: '/politica-privacidad', statusCode: 301 },
     },
     prerender: {
       routes: [


### PR DESCRIPTION
## Summary
- Add 301 redirects for 2 legacy URLs causing 404 errors in Google Search Console
- `/gana/politicas-privacidad.html` → `/gana/politicas-privacidad`
- `/tratamiento-datos-alquilatucarro.pdf` → `/politica-privacidad`

## Test plan
- [ ] Deploy to production
- [ ] Verify redirects work: `curl -I https://alquilatucarro.com/gana/politicas-privacidad.html`
- [ ] Click "Validar corrección" in GSC for the 404 errors