### PR TITLE
fix(cls): Sedes section responsive width classes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -33,7 +33,7 @@ export default defineNuxtConfig({
             .w-2\\.5 { width: 0.625rem; } .h-2\\.5 { height: 0.625rem; }
             .w-4 { width: 1rem; } .h-4 { height: 1rem; }
             .w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
-            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } .md\\:text-base { font-size: 1rem; line-height: 1.5rem; } }
+            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } .md\\:text-base { font-size: 1rem; line-height: 1.5rem; } .md\\:w-fit { width: fit-content; } .md\\:flex-row { flex-direction: row; } .md\\:flex-wrap { flex-wrap: wrap; } }
             .mx-auto { margin-left: auto; margin-right: auto; }
             @media (min-width: 768px) { header .md\\:hidden { display: none !important; } header .md\\:flex { display: flex !important; } }
             @media (max-width: 767px) { header .hidden { display: none !important; } }


### PR DESCRIPTION
## Summary
- Add `md:w-fit`, `md:flex-row`, `md:flex-wrap` to critical CSS
- Fixes city buttons in Sedes section being too wide on desktop
- Buttons now shrink to fit content on md+ screens while remaining full-width on mobile

## Test plan
- [ ] Verify Sedes section buttons on mobile (should be full width)
- [ ] Verify Sedes section buttons on desktop (should be fit-content width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)