### PR TITLE
fix(seo): use Nitro serverAssets for Firebase compatibility

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -333,6 +333,13 @@ export default defineNuxtConfig({
         maxInstances: 1,
       },
     },
+    // SEO data files - bundled with server for Firebase Functions
+    serverAssets: [
+      {
+        baseName: 'seo-data',
+        dir: './docs/seo/data'
+      }
+    ],
     esbuild: {
       options: {
         target: 'node20'

--- a/server/api/seo/activity.get.ts
+++ b/server/api/seo/activity.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/activity.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:activity.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/backlinks.get.ts
+++ b/server/api/seo/backlinks.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/backlinks.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:backlinks.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/competitors.get.ts
+++ b/server/api/seo/competitors.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/competitors.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:competitors.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/content.get.ts
+++ b/server/api/seo/content.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/content.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:content.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/keywords.get.ts
+++ b/server/api/seo/keywords.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/keywords.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:keywords.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/metrics.get.ts
+++ b/server/api/seo/metrics.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/metrics.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:metrics.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/performance.get.ts
+++ b/server/api/seo/performance.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/performance.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:performance.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/tasks.get.ts
+++ b/server/api/seo/tasks.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/tasks.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:tasks.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,

--- a/server/api/seo/tools.get.ts
+++ b/server/api/seo/tools.get.ts
@@ -1,11 +1,7 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-
 export default defineEventHandler(async () => {
   try {
-    const dataPath = join(process.cwd(), 'docs/seo/data/tools.json')
-    const data = readFileSync(dataPath, 'utf-8')
-    return JSON.parse(data)
+    const data = await useStorage('assets:server').getItem('seo-data:tools.json')
+    return data
   } catch (error) {
     throw createError({
       statusCode: 500,


### PR DESCRIPTION
## Summary
- Replace `readFileSync` with `useStorage` for SEO data APIs
- Add `serverAssets` config to bundle `docs/seo/data` in server
- Fixes 500 errors in production where fs reads fail on Firebase Functions

## Problem
The SEO dashboard showed all zeros in production because:
1. API handlers used `readFileSync` with `process.cwd()` 
2. In Firebase Functions, `docs/seo/data/` doesn't exist at runtime
3. The files weren't bundled with the server deployment

## Solution
- Configure Nitro `serverAssets` to include SEO data files in the server bundle
- Update all SEO API handlers to use `useStorage('assets:server')` instead of `readFileSync`

## Test plan
- [ ] Deploy to Firebase via CI/CD
- [ ] Navigate to /seo/login and authenticate
- [ ] Verify backlinks page shows data (totalFollow: 3514, etc.)
- [ ] Verify metrics shows DA: 53, PA: 39