### PR TITLE
feat(gsc): migrate token storage to Firestore

### DIFF
--- a/server/api/auth/gsc/callback.get.ts
+++ b/server/api/auth/gsc/callback.get.ts
@@ -1,5 +1,4 @@
-import { writeFileSync, mkdirSync, existsSync } from 'fs'
-import { resolve } from 'path'
+import { saveGscTokens } from '../../../utils/gsc'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -43,12 +42,7 @@ export default defineEventHandler(async (event) => {
       }
     })
 
-    // Store tokens securely
-    const tokensDir = resolve(process.cwd(), 'docs/seo/data/.tokens')
-    if (!existsSync(tokensDir)) {
-      mkdirSync(tokensDir, { recursive: true })
-    }
-
+    // Save tokens to Firestore
     const tokenData = {
       access_token: tokenResponse.access_token,
       refresh_token: tokenResponse.refresh_token,
@@ -58,16 +52,8 @@ export default defineEventHandler(async (event) => {
       created_at: new Date().toISOString()
     }
 
-    writeFileSync(
-      resolve(tokensDir, 'gsc-tokens.json'),
-      JSON.stringify(tokenData, null, 2)
-    )
+    await saveGscTokens(tokenData)
 
-    // Update tools.json to reflect connected status
-    const toolsPath = resolve(process.cwd(), 'docs/seo/data/tools.json')
-    const tools = JSON.parse(await useStorage().getItem('assets:server:tools.json') as string || '{}')
-
-    // We'll update tools.json through the API instead
     return sendRedirect(event, '/seo/herramientas?success=gsc_connected')
 
   } catch (err: any) {

--- a/server/api/auth/gsc/status.get.ts
+++ b/server/api/auth/gsc/status.get.ts
@@ -1,8 +1,8 @@
 import { isGscConnected, getGscTokens } from '../../../utils/gsc'
 
-export default defineEventHandler(() => {
-  const connected = isGscConnected()
-  const tokens = getGscTokens()
+export default defineEventHandler(async () => {
+  const connected = await isGscConnected()
+  const tokens = await getGscTokens()
 
   return {
     connected,

--- a/server/api/seo/update.post.ts
+++ b/server/api/seo/update.post.ts
@@ -119,7 +119,7 @@ export default defineEventHandler(async (event): Promise<UpdateResult> => {
   if (services.includes('gsc')) {
     try {
       // Check if GSC is connected via OAuth tokens
-      const gscConnected = isGscConnected()
+      const gscConnected = await isGscConnected()
 
       if (!gscConnected) {
         result.errors.push('GSC no conectado - usa el botón "Conectar GSC" para autorizar')

--- a/server/utils/firebase.ts
+++ b/server/utils/firebase.ts
@@ -1,0 +1,35 @@
+import { initializeApp, getApps, cert, type App } from 'firebase-admin/app'
+import { getFirestore, type Firestore } from 'firebase-admin/firestore'
+
+let app: App | null = null
+let db: Firestore | null = null
+
+/**
+ * Initialize Firebase Admin SDK
+ * In Firebase Functions/Cloud Run, credentials are auto-detected
+ * Locally, use GOOGLE_APPLICATION_CREDENTIALS env var or service account
+ */
+export function getFirebaseApp(): App {
+  if (app) return app
+
+  const apps = getApps()
+  if (apps.length > 0) {
+    app = apps[0]
+    return app
+  }
+
+  // Initialize with auto-detected credentials (works in Firebase/GCP environments)
+  app = initializeApp()
+  return app
+}
+
+/**
+ * Get Firestore instance
+ */
+export function getFirestoreDb(): Firestore {
+  if (db) return db
+
+  getFirebaseApp()
+  db = getFirestore()
+  return db
+}


### PR DESCRIPTION
## Summary
- Migra el almacenamiento de tokens GSC del filesystem local a Firestore
- Resuelve el problema de tokens perdidos en Cloud Run (filesystem efímero)
- Los tokens ahora persisten entre reinicios de contenedor

## Cambios
- `server/utils/firebase.ts` - Nueva utilidad para inicializar Firebase Admin
- `server/utils/gsc.ts` - Refactorizado para usar Firestore
- Endpoints actualizados para operaciones async

## Test plan
- [ ] Conectar GSC en producción
- [ ] Verificar que tokens persisten después de re-deploy