### PR TITLE
fix(seo): add 301 redirects for 404 URLs with backlinks

### DIFF
--- a/docs/seo/data/backlinks.json
+++ b/docs/seo/data/backlinks.json
@@ -50,20 +50,26 @@
       "url": "/images/carros2.png",
       "linkingDomains": 19,
       "pa": 30,
-      "status": "pending-redirect"
+      "status": "redirected",
+      "redirectTo": "/",
+      "redirectedAt": "2026-01-19"
     },
     {
       "url": "/imacion/ani2a.png",
       "linkingDomains": 3,
       "pa": 25,
-      "status": "pending-redirect"
+      "status": "redirected",
+      "redirectTo": "/",
+      "redirectedAt": "2026-01-19"
     },
     {
       "url": "/-coche-en-espana/",
       "linkingDomains": 1,
       "pa": 23,
-      "status": "pending-redirect"
+      "status": "redirected",
+      "redirectTo": "/",
+      "redirectedAt": "2026-01-19"
     }
   ],
-  "lastUpdated": "2026-01-17"
+  "lastUpdated": "2026-01-19"
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -537,6 +537,11 @@ export default defineNuxtConfig({
       // Redirects para URLs legacy (404s en Google Search Console)
       '/gana/politicas-privacidad.html': { redirect: '/gana/politicas-privacidad', statusCode: 301 },
       '/tratamiento-datos-alquilatucarro.pdf': { redirect: '/politica-privacidad', statusCode: 301 },
+      // Redirects para URLs 404 con backlinks (preservar link equity)
+      // Fuente: SEO Dashboard - URLs 404 con Backlinks (19 + 3 + 1 = 23 linking domains)
+      '/images/carros2.png': { redirect: '/', statusCode: 301 },
+      '/imacion/ani2a.png': { redirect: '/', statusCode: 301 },
+      '/-coche-en-espana/': { redirect: '/', statusCode: 301 },
     },
     prerender: {
       routes: [


### PR DESCRIPTION
## Summary
- Add 301 redirects for 3 URLs returning 404 that have external backlinks
- Preserve link equity from 23 linking domains total
- Update backlinks.json to reflect redirected status

## URLs Redirected
| URL | Linking Domains | Redirect To |
|-----|-----------------|-------------|
| `/images/carros2.png` | 19 | `/` |
| `/imacion/ani2a.png` | 3 | `/` |
| `/-coche-en-espana/` | 1 | `/` |

## Test plan
- [ ] Verify redirects work after deploy: `curl -I https://alquilatucarro.com/images/carros2.png`
- [ ] Check HTTP status is 301
- [ ] Confirm Location header points to homepage