### PR TITLE
fix(ui): Mejorar contraste del calendario en Searcher

### DIFF
--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -407,19 +407,9 @@ header [data-highlighted],
     background-color: white !important;
 }
 
-/* Calendar day cells */
-.calendar-light [role="gridcell"] button {
-    color: #1f2937 !important;
-}
-
+/* Calendar day cells - configuration moved to component :ui prop */
 .calendar-light [role="gridcell"] button:hover {
     background-color: #f3f4f6 !important;
-}
-
-/* Days outside current month */
-.calendar-light [data-outside-view] button,
-.calendar-light [data-disabled] button {
-    color: #9ca3af !important;
 }
 
 /* UModal customization - remove header divider and reduce spacing */

--- a/packages/ui-alquilatucarro/app/components/Searcher.vue
+++ b/packages/ui-alquilatucarro/app/components/Searcher.vue
@@ -135,6 +135,7 @@
                                     class="p-2 calendar-light"
                                     :min-value="minPickupDate"
                                     color="success"
+                                    :ui="calendarUIConfig"
                                 />
                             </template>
                         </u-popover>
@@ -190,6 +191,7 @@
                                     :min-value="minPickupDate"
                                     :max-value="maxReturnDate"
                                     color="success"
+                                    :ui="calendarUIConfig"
                                 />
                             </template>
                         </u-popover>
@@ -299,6 +301,12 @@ const animateSearchButton = ref<boolean>(true);
 
 const pickupDateCalendarOpen = ref<boolean>(false);
 const returnDateCalendarOpen = ref<boolean>(false);
+
+// Calendar UI configuration for better contrast
+const calendarUIConfig = {
+    heading: '!text-gray-900 !font-bold',
+    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-300 data-[disabled]:!opacity-40 data-[unavailable]:!text-gray-300 data-[unavailable]:!opacity-40 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
+};
 
 // Initialize stores only on client side after mount
 onMounted(() => {


### PR DESCRIPTION
## Resumen
Mejora el contraste de colores en el componente `u-calendar` del formulario de búsqueda (Searcher.vue) para mejor legibilidad.

## Problema
Los días disponibles se mostraban en gris claro apenas visible, mientras que los días no disponibles se mostraban en negro, causando confusión visual.

## Solución
- **Días disponibles**: Negro oscuro (`text-gray-900`) con negrita para máxima visibilidad
- **Días deshabilitados/no disponibles**: Gris claro (`text-gray-300`) con 40% opacidad
- **Encabezado mes/año**: Negro oscuro con negrita
- Configuración implementada usando la prop `:ui` del componente `UCalendar` (método oficial Nuxt UI v4)
- Simplificado CSS en `base.css` removiendo estilos obsoletos

## Archivos modificados
- `packages/ui-alquilatucarro/app/components/Searcher.vue` - Añadida configuración UI
- `packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css` - Simplificado CSS

## Test plan
- [x] Verificar que días disponibles se ven en negro oscuro
- [x] Verificar que días no disponibles se ven en gris claro con opacidad
- [x] Verificar que el encabezado del mes se ve en negro oscuro
- [x] Verificar funcionamiento en calendarios de recogida y devolución