### PR TITLE
fix(ci): Resolver conflicto de versión de pnpm en workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   NODE_VERSION: '20'
-  PNPM_VERSION: '9'
 
 jobs:
   quality-checks:
@@ -27,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Get pnpm store directory
         shell: bash
@@ -72,8 +69,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,8 +136,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Problema
Error en GitHub Actions después del merge del PR #92:
```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.0.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

## Causa
Ambos workflows (`ci.yml` y `deploy.yml`) especificaban explícitamente la versión de pnpm, mientras que `package.json` ya define `"packageManager": "pnpm@9.0.0"`.

## Solución
Remover todas las especificaciones explícitas de versión de pnpm en los workflows. `pnpm/action-setup@v4` detecta automáticamente la versión desde el campo `packageManager` en `package.json`.

## Cambios
- **deploy.yml**: Removida línea `version: 9` del step Setup pnpm
- **ci.yml**: Removida variable de entorno `PNPM_VERSION: '9'` y sus 2 referencias en los steps de Setup pnpm

## Archivos modificados
- `.github/workflows/deploy.yml` (-3 líneas)
- `.github/workflows/ci.yml` (-4 líneas)

## Referencias
- [pnpm/action-setup documentation](https://github.com/pnpm/action-setup#inputs)
- Relacionado con PR #92 (merge que activó el error)