### PR TITLE
fix(ui): Mejorar contraste del calendario en alquilame y alquicarros

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
@@ -407,19 +407,9 @@ header [data-highlighted],
     background-color: white !important;
 }
 
-/* Calendar day cells */
-.calendar-light [role="gridcell"] button {
-    color: #1f2937 !important;
-}
-
+/* Calendar day cells - configuration moved to component :ui prop */
 .calendar-light [role="gridcell"] button:hover {
     background-color: #f3f4f6 !important;
-}
-
-/* Days outside current month */
-.calendar-light [data-outside-view] button,
-.calendar-light [data-disabled] button {
-    color: #9ca3af !important;
 }
 
 /* UModal customization - remove header divider and reduce spacing */

--- a/packages/ui-alquicarros/app/components/Searcher.vue
+++ b/packages/ui-alquicarros/app/components/Searcher.vue
@@ -134,6 +134,7 @@
                                     class="p-2 calendar-light"
                                     :min-value="minPickupDate"
                                     color="success"
+                                    :ui="calendarUIConfig"
                                 />
                             </template>
                         </u-popover>
@@ -188,6 +189,7 @@
                                     :min-value="minPickupDate"
                                     :max-value="maxReturnDate"
                                     color="success"
+                                    :ui="calendarUIConfig"
                                 />
                             </template>
                         </u-popover>
@@ -307,6 +309,12 @@ const {
 
 const pickupDateCalendarOpen = ref<boolean>(false);
 const returnDateCalendarOpen = ref<boolean>(false);
+
+// Calendar UI configuration for better contrast
+const calendarUIConfig = {
+    heading: '!text-gray-900 !font-bold',
+    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-300 data-[disabled]:!opacity-40 data-[unavailable]:!text-gray-300 data-[unavailable]:!opacity-40 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
+};
 
 </script>
 

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
@@ -407,19 +407,9 @@ header [data-highlighted],
     background-color: white !important;
 }
 
-/* Calendar day cells */
-.calendar-light [role="gridcell"] button {
-    color: #1f2937 !important;
-}
-
+/* Calendar day cells - configuration moved to component :ui prop */
 .calendar-light [role="gridcell"] button:hover {
     background-color: #f3f4f6 !important;
-}
-
-/* Days outside current month */
-.calendar-light [data-outside-view] button,
-.calendar-light [data-disabled] button {
-    color: #9ca3af !important;
 }
 
 /* UModal customization - remove header divider and reduce spacing */

--- a/packages/ui-alquilame/app/components/Searcher.vue
+++ b/packages/ui-alquilame/app/components/Searcher.vue
@@ -134,6 +134,7 @@
                                     class="p-2 calendar-light"
                                     :min-value="minPickupDate"
                                     color="success"
+                                    :ui="calendarUIConfig"
                                 />
                             </template>
                         </u-popover>
@@ -188,6 +189,7 @@
                                     :min-value="minPickupDate"
                                     :max-value="maxReturnDate"
                                     color="success"
+                                    :ui="calendarUIConfig"
                                 />
                             </template>
                         </u-popover>
@@ -307,6 +309,12 @@ const {
 
 const pickupDateCalendarOpen = ref<boolean>(false);
 const returnDateCalendarOpen = ref<boolean>(false);
+
+// Calendar UI configuration for better contrast
+const calendarUIConfig = {
+    heading: '!text-gray-900 !font-bold',
+    cellTrigger: '!text-gray-900 !font-semibold data-[disabled]:!text-gray-300 data-[disabled]:!opacity-40 data-[unavailable]:!text-gray-300 data-[unavailable]:!opacity-40 data-[outside-view]:!text-gray-400 data-[outside-view]:!opacity-50'
+};
 
 </script>
 


### PR DESCRIPTION
## Resumen
Replica las mejoras de contraste del calendario implementadas en alquilatucarro a las otras dos marcas (alquilame y alquicarros).

## Cambios realizados
- ✅ Configura colores de días disponibles/inhabilitados usando prop `:ui` de UCalendar
- ✅ Mejora contraste del encabezado del calendario (mes/año)
- ✅ Simplifica CSS moviendo lógica de estilos al componente
- ✅ Mantiene coherencia visual entre las tres marcas

## Archivos modificados
- `packages/ui-alquilame/app/components/Searcher.vue`
- `packages/ui-alquilame/app/assets/css/rentacar-main/base.css`
- `packages/ui-alquicarros/app/components/Searcher.vue`
- `packages/ui-alquicarros/app/assets/css/rentacar-main/base.css`

## Impacto
- Mejora la accesibilidad y legibilidad del calendario en dispositivos desktop
- Mantiene consistencia visual entre las tres marcas del monorepo
- Reduce código CSS redundante

## Plan de prueba
- [x] Verificar contraste adecuado de días disponibles vs inhabilitados
- [x] Verificar legibilidad del encabezado del calendario (mes/año)
- [ ] Probar en ambas marcas (alquilame y alquicarros)
- [x] Verificar que el calendario funciona correctamente en mobile y desktop