### PR TITLE
fix(seo): valid HTML semantics in headings across all brands

### DIFF
--- a/packages/ui-alquicarros/app/components/Hero/Title.vue
+++ b/packages/ui-alquicarros/app/components/Hero/Title.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="hero-h1-critical text-white text-4xl text-center font-bold">
+  <span class="block hero-h1-critical text-white text-4xl text-center font-bold">
     <span class="block">
       <span class="block uppercase">ALQUILER</span>
+      {{ ' ' }}
       <span class="block">DE CARROS EN</span>
     </span>
+    {{ ' ' }}
     <span class="block tracking-wide colombia-sweep">COLOMBIA</span>
-  </div>
+  </span>
 </template>

--- a/packages/ui-alquicarros/app/pages/index.vue
+++ b/packages/ui-alquicarros/app/pages/index.vue
@@ -35,10 +35,11 @@
       class="bg-white text-black"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center">
+        <span class="block text-2xl md:text-3xl text-center">
           <span class="block text-red-700">Hasta 60% de Descuento</span>
+          {{ ' ' }}
           <span class="block text-black">Reserva Ahora, Paga Después</span>
-        </div>
+        </span>
       </template>
       <template #description>
         <div class="text-black text-center">
@@ -64,10 +65,9 @@
       class="bg-gray-200 text-black"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center space-x-2">
-          <span class="text-red-700">Requisitos</span>
-          <span class="text-black">para tu alquiler</span>
-        </div>
+        <span class="block text-2xl md:text-3xl text-center">
+          <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
+        </span>
       </template>
       <template #description>
         <div class="text-black justify-items-center">
@@ -122,10 +122,9 @@
       :ui="categoriasPageSectionUIConfig"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center space-x-2">
-          <span class="text-red-700">Tipos de Vehículos</span>
-          <span class="text-black">ideales para tu necesidad</span>
-        </div>
+        <span class="block text-2xl md:text-3xl text-center">
+          <span class="text-red-700">Tipos de Vehículos</span>{{ ' ' }}<span class="text-black">ideales para tu necesidad</span>
+        </span>
       </template>
       <template #description>
         <div class="text-black justify-items-center">
@@ -206,9 +205,8 @@
     <!-- Testimonials Section -->
     <section id="testimonios" class="bg-gray-200 text-black py-12 md:py-20 px-4 md:px-8">
       <div class="max-w-7xl mx-auto">
-        <h2 class="text-2xl md:text-3xl text-center space-x-2 mb-4">
-          <span class="text-red-700">Testimonios</span>
-          <span class="text-black">que comparten nuestros clientes</span>
+        <h2 class="text-2xl md:text-3xl text-center mb-4">
+          <span class="text-red-700">Testimonios</span>{{ ' ' }}<span class="text-black">que comparten nuestros clientes</span>
         </h2>
         <p class="text-black text-center mb-8">Descubre por qué somos la opción preferida para alquilar carros en Colombia. Nuestros clientes destacan nuestra atención, precios competitivos y la facilidad para explorar.</p>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -238,19 +236,18 @@
     <!-- FAQ Section -->
     <UPageSection id="faqs" class="bg-white text-black">
       <div class="max-w-7xl mx-auto px-1 sm:px-2 lg:px-6">
-        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6 space-x-2">
-          <span class="text-red-700">Preguntas Frecuentes</span>
-          <span class="text-black">sobre alquiler de carros</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6">
+          <span class="text-red-700">Preguntas Frecuentes</span>{{ ' ' }}<span class="text-black">sobre alquiler de carros</span>
         </h2>
         <p class="text-base text-center mb-4">
           Encuentra respuestas a las consultas más comunes sobre nuestro servicio de alquiler. Si tienes otra pregunta, contáctanos directamente.
         </p>
         <LazyUAccordion hydrate-on-interaction :items="faqs" :ui="faqAccordionUIConfig" class="max-w-4xl mx-auto">
           <template #default="{ item }">
-            <div class="text-base font-medium text-gray-800 px-4" v-text="item.label"></div>
+            <span class="block text-base font-medium text-gray-800 px-4" v-text="item.label"></span>
           </template>
           <template #content="{ item }">
-            <div class="text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></div>
+            <span class="block text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></span>
           </template>
         </LazyUAccordion>
       </div>

--- a/packages/ui-alquilame/app/components/Hero/Title.vue
+++ b/packages/ui-alquilame/app/components/Hero/Title.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="hero-h1-critical text-white text-4xl text-center font-bold">
+  <span class="block hero-h1-critical text-white text-4xl text-center font-bold">
     <span class="block">
       <span class="block uppercase">ALQUILER</span>
+      {{ ' ' }}
       <span class="block">DE CARROS EN</span>
     </span>
+    {{ ' ' }}
     <span class="block tracking-wide colombia-sweep">COLOMBIA</span>
-  </div>
+  </span>
 </template>

--- a/packages/ui-alquilame/app/pages/index.vue
+++ b/packages/ui-alquilame/app/pages/index.vue
@@ -35,10 +35,11 @@
       class="bg-white text-black"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center">
+        <span class="block text-2xl md:text-3xl text-center">
           <span class="block text-red-700">Hasta 60% de Descuento</span>
+          {{ ' ' }}
           <span class="block text-black">Reserva Ahora, Paga Después</span>
-        </div>
+        </span>
       </template>
       <template #description>
         <div class="text-black text-center">
@@ -64,10 +65,9 @@
       class="bg-gray-200 text-black"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center space-x-2">
-          <span class="text-red-700">Requisitos</span>
-          <span class="text-black">para tu alquiler</span>
-        </div>
+        <span class="block text-2xl md:text-3xl text-center">
+          <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
+        </span>
       </template>
       <template #description>
         <div class="text-black justify-items-center">
@@ -122,10 +122,9 @@
       :ui="categoriasPageSectionUIConfig"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center space-x-2">
-          <span class="text-red-700">Tipos de Vehículos</span>
-          <span class="text-black">ideales para tu necesidad</span>
-        </div>
+        <span class="block text-2xl md:text-3xl text-center">
+          <span class="text-red-700">Tipos de Vehículos</span>{{ ' ' }}<span class="text-black">ideales para tu necesidad</span>
+        </span>
       </template>
       <template #description>
         <div class="text-black justify-items-center">
@@ -206,9 +205,8 @@
     <!-- Testimonials Section -->
     <section id="testimonios" class="bg-gray-200 text-black py-12 md:py-20 px-4 md:px-8">
       <div class="max-w-7xl mx-auto">
-        <h2 class="text-2xl md:text-3xl text-center space-x-2 mb-4">
-          <span class="text-red-700">Testimonios</span>
-          <span class="text-black">que comparten nuestros clientes</span>
+        <h2 class="text-2xl md:text-3xl text-center mb-4">
+          <span class="text-red-700">Testimonios</span>{{ ' ' }}<span class="text-black">que comparten nuestros clientes</span>
         </h2>
         <p class="text-black text-center mb-8">Descubre por qué somos la opción preferida para alquilar carros en Colombia. Nuestros clientes destacan nuestra atención, precios competitivos y la facilidad para explorar.</p>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -238,19 +236,18 @@
     <!-- FAQ Section -->
     <UPageSection id="faqs" class="bg-white text-black">
       <div class="max-w-7xl mx-auto px-1 sm:px-2 lg:px-6">
-        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6 space-x-2">
-          <span class="text-red-700">Preguntas Frecuentes</span>
-          <span class="text-black">sobre alquiler de carros</span>
+        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6">
+          <span class="text-red-700">Preguntas Frecuentes</span>{{ ' ' }}<span class="text-black">sobre alquiler de carros</span>
         </h2>
         <p class="text-base text-center mb-4">
           Encuentra respuestas a las consultas más comunes sobre nuestro servicio de alquiler. Si tienes otra pregunta, contáctanos directamente.
         </p>
         <LazyUAccordion hydrate-on-interaction :items="faqs" :ui="faqAccordionUIConfig" class="max-w-4xl mx-auto">
           <template #default="{ item }">
-            <div class="text-base font-medium text-gray-800 px-4" v-text="item.label"></div>
+            <span class="block text-base font-medium text-gray-800 px-4" v-text="item.label"></span>
           </template>
           <template #content="{ item }">
-            <div class="text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></div>
+            <span class="block text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></span>
           </template>
         </LazyUAccordion>
       </div>

--- a/packages/ui-alquilatucarro/app/components/Hero/Title.vue
+++ b/packages/ui-alquilatucarro/app/components/Hero/Title.vue
@@ -1,8 +1,9 @@
 <template>
-  <div class="hero-h1-critical text-white text-4xl text-center font-bold">
+  <span class="block hero-h1-critical text-white text-4xl text-center font-bold">
     <span class="block uppercase">
-      ALQUILER<br>DE CARROS EN
+      ALQUILER <br>DE CARROS EN
     </span>
+    {{ ' ' }}
     <span class="block tracking-wide colombia-sweep">COLOMBIA</span>
-  </div>
+  </span>
 </template>

--- a/packages/ui-alquilatucarro/app/pages/index.vue
+++ b/packages/ui-alquilatucarro/app/pages/index.vue
@@ -35,11 +35,11 @@
       class="bg-white text-black"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center">
+        <span class="block text-2xl md:text-3xl text-center">
           <span class="block text-red-700">Hasta 60% de Descuento</span>
-          <br>
+          {{ ' ' }}
           <span class="block text-black">Reserva Ahora, Paga Después</span>
-        </div>
+        </span>
       </template>
       <template #description>
         <div class="text-black text-center">
@@ -65,9 +65,9 @@
       class="bg-gray-200 text-black"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center">
+        <span class="block text-2xl md:text-3xl text-center">
           <span class="text-red-700">Requisitos</span>{{ ' ' }}<span class="text-black">para tu alquiler</span>
-        </div>
+        </span>
       </template>
       <template #description>
         <div class="text-black justify-items-center">
@@ -122,9 +122,9 @@
       :ui="categoriasPageSectionUIConfig"
     >
       <template #title>
-        <div class="text-2xl md:text-3xl text-center">
+        <span class="block text-2xl md:text-3xl text-center">
           <span class="text-red-700">Tipos de Vehículos</span>{{ ' ' }}<span class="text-black">ideales para tu necesidad</span>
-        </div>
+        </span>
       </template>
       <template #description>
         <div class="text-black justify-items-center">
@@ -244,10 +244,10 @@
         </p>
         <LazyUAccordion hydrate-on-interaction :items="faqs" :ui="faqAccordionUIConfig" class="max-w-4xl mx-auto">
           <template #default="{ item }">
-            <div class="text-base font-medium text-gray-800 px-4" v-text="item.label"></div>
+            <span class="block text-base font-medium text-gray-800 px-4" v-text="item.label"></span>
           </template>
           <template #content="{ item }">
-            <div class="text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></div>
+            <span class="block text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content"></span>
           </template>
         </LazyUAccordion>
       </div>


### PR DESCRIPTION
## Summary
- Replace `<div>` with `<span class="block">` inside heading slots (H1/H2) to produce valid HTML — `<div>` is flow content and invalid inside `<h1>`/`<h2>`, while `<span>` is phrasing content (valid) with `display:block` for same visual layout
- Fix text concatenation issues where crawlers reading `textContent` see "ALQUILERDE" (H1) and "DescuentoReserva" (H2 Video) due to missing text node separators
- Replace `space-x-2` CSS class (only adds visual margin, invisible to `textContent`) with `{{ ' ' }}` literal space nodes on alquilame/alquicarros headings
- Fix 11x `<div>` inside `<span>` W3C errors in FAQ accordion templates across all 3 brands

## Files changed (6)
- `packages/ui-{brand}/app/components/Hero/Title.vue` (x3) — H1 div→span fix
- `packages/ui-{brand}/app/pages/index.vue` (x3) — H2 div→span, FAQ accordion, text spacing

## Test plan
- [ ] Verify homepage renders identically (no visual regression) on all 3 brands
- [ ] Run W3C Validator — confirm `<div>` inside heading errors are gone
- [ ] Check `document.querySelector('h1').textContent` includes spaces between words
- [ ] Check `document.querySelector('h2').textContent` on Video section includes space
- [ ] Verify FAQ accordion still opens/closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)