### PR TITLE
fix(search): prevent page re-mount loop when selecting vehicle category

### DIFF
--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -261,30 +261,22 @@ const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 // Flag para evitar loops cuando actualizamos la URL programáticamente
 const isUpdatingFromUrl = ref(false);
 
-// Navegar a URL con categoría o limpiar categoría de la URL
+// Actualizar URL con categoría sin disparar navegación Vue Router.
+// Usa history.replaceState para evitar que Nuxt desmonte/remonte la página
+// (la ruta /categoria/[codigo] es una página Nuxt separada, y router.replace
+// causaba re-mount → re-search → scroll al tope → loop).
 function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   if (!import.meta.client) return;
 
-  const router = useRouter();
-  const route = useRoute();
+  const currentPath = window.location.pathname;
+  const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^/]+$/, '');
 
   if (codigoCategoria) {
-    // Construir nueva ruta con /categoria/[codigo]
-    const currentPath = route.path;
-    const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^\/]+$/, '');
     const newPath = `${basePathWithoutCategoria}/categoria/${codigoCategoria.toLowerCase()}`;
-
-    // Si se marca "reservar", usar query param para abrir form directamente
-    if (reservar) {
-      router.replace({ path: newPath, query: { reservar: codigoCategoria } });
-    } else {
-      router.replace({ path: newPath });
-    }
+    const newUrl = reservar ? `${newPath}?reservar=${codigoCategoria}` : newPath;
+    window.history.replaceState(window.history.state, '', newUrl);
   } else {
-    // Limpiar categoría de la URL (volver a ruta sin /categoria/)
-    const currentPath = route.path;
-    const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^\/]+$/, '');
-    router.replace({ path: basePathWithoutCategoria });
+    window.history.replaceState(window.history.state, '', basePathWithoutCategoria);
   }
 }
 

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -261,30 +261,22 @@ const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 // Flag para evitar loops cuando actualizamos la URL programáticamente
 const isUpdatingFromUrl = ref(false);
 
-// Navegar a URL con categoría o limpiar categoría de la URL
+// Actualizar URL con categoría sin disparar navegación Vue Router.
+// Usa history.replaceState para evitar que Nuxt desmonte/remonte la página
+// (la ruta /categoria/[codigo] es una página Nuxt separada, y router.replace
+// causaba re-mount → re-search → scroll al tope → loop).
 function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   if (!import.meta.client) return;
 
-  const router = useRouter();
-  const route = useRoute();
+  const currentPath = window.location.pathname;
+  const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^/]+$/, '');
 
   if (codigoCategoria) {
-    // Construir nueva ruta con /categoria/[codigo]
-    const currentPath = route.path;
-    const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^\/]+$/, '');
     const newPath = `${basePathWithoutCategoria}/categoria/${codigoCategoria.toLowerCase()}`;
-
-    // Si se marca "reservar", usar query param para abrir form directamente
-    if (reservar) {
-      router.replace({ path: newPath, query: { reservar: codigoCategoria } });
-    } else {
-      router.replace({ path: newPath });
-    }
+    const newUrl = reservar ? `${newPath}?reservar=${codigoCategoria}` : newPath;
+    window.history.replaceState(window.history.state, '', newUrl);
   } else {
-    // Limpiar categoría de la URL (volver a ruta sin /categoria/)
-    const currentPath = route.path;
-    const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^\/]+$/, '');
-    router.replace({ path: basePathWithoutCategoria });
+    window.history.replaceState(window.history.state, '', basePathWithoutCategoria);
   }
 }
 

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -261,30 +261,22 @@ const abrirFormularioDirecto = computed(() => !!reservarParam.value);
 // Flag para evitar loops cuando actualizamos la URL programáticamente
 const isUpdatingFromUrl = ref(false);
 
-// Navegar a URL con categoría o limpiar categoría de la URL
+// Actualizar URL con categoría sin disparar navegación Vue Router.
+// Usa history.replaceState para evitar que Nuxt desmonte/remonte la página
+// (la ruta /categoria/[codigo] es una página Nuxt separada, y router.replace
+// causaba re-mount → re-search → scroll al tope → loop).
 function updateCategoriaUrl(codigoCategoria?: string, reservar?: boolean) {
   if (!import.meta.client) return;
 
-  const router = useRouter();
-  const route = useRoute();
+  const currentPath = window.location.pathname;
+  const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^/]+$/, '');
 
   if (codigoCategoria) {
-    // Construir nueva ruta con /categoria/[codigo]
-    const currentPath = route.path;
-    const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^\/]+$/, '');
     const newPath = `${basePathWithoutCategoria}/categoria/${codigoCategoria.toLowerCase()}`;
-
-    // Si se marca "reservar", usar query param para abrir form directamente
-    if (reservar) {
-      router.replace({ path: newPath, query: { reservar: codigoCategoria } });
-    } else {
-      router.replace({ path: newPath });
-    }
+    const newUrl = reservar ? `${newPath}?reservar=${codigoCategoria}` : newPath;
+    window.history.replaceState(window.history.state, '', newUrl);
   } else {
-    // Limpiar categoría de la URL (volver a ruta sin /categoria/)
-    const currentPath = route.path;
-    const basePathWithoutCategoria = currentPath.replace(/\/categoria\/[^\/]+$/, '');
-    router.replace({ path: basePathWithoutCategoria });
+    window.history.replaceState(window.history.state, '', basePathWithoutCategoria);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Bug**: Clicking "Solicitar este vehículo" on city search results caused the slideover to open/close, page scroll to top, re-trigger search API, and loop when closing the panel
- **Root cause**: `updateCategoriaUrl()` used `router.replace()` to navigate to `/categoria/[codigo]`, which is a separate Nuxt page file — causing full page re-mount → `useSearchByRouteParams()` → `doSearch()` → scroll reset → loop
- **Fix**: Replace `router.replace()` with `window.history.replaceState()` to update the URL silently without triggering Vue Router navigation. Deep-linking via shared URLs still works (the `/categoria/[categoria]/index.vue` page handles initial loads)

## Files changed
- `packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue`
- `packages/ui-alquilame/app/components/CategorySelectionSection.vue`
- `packages/ui-alquicarros/app/components/CategorySelectionSection.vue`

## Test plan
- [ ] Navigate to a city page (e.g., `/bogota`), search vehicles, click "Solicitar este vehículo" — slideover should open without page scroll or re-search
- [ ] Close the slideover — page should stay in place, no re-search triggered
- [ ] Open a shared URL with `/categoria/c` suffix — slideover should auto-open correctly (deep-link)
- [ ] Verify share buttons (WhatsApp, Facebook, X, copy link) generate correct URLs with `/categoria/` path
- [ ] Repeat on alquilame.com and alquicarros.com