### PR TITLE
fix(seo): HTML semantics, image sources and search page fixes

### DIFF
--- a/packages/ui-alquicarros/app/components/Images/Persona.vue
+++ b/packages/ui-alquicarros/app/components/Images/Persona.vue
@@ -30,36 +30,6 @@
       width="2000"
       height="1620"
     />
-    <!-- persona webp movil -->
-    <source
-      type="image/webp"
-      media="(max-width: 767px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona-movil.avif?alt=media&token=0085aaff-80de-4260-9a36-12412ae77b4c
-      "
-      width="333"
-      height="270"
-    />
-    <!-- persona png -->
-    <source
-      type="image/png"
-      media="(min-width: 768px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona.webp?alt=media&token=8d98ef71-c9b8-4357-8093-ba9cf0aaa2e8
-      "
-      width="2000"
-      height="1620"
-    />
-    <!-- persona movil png -->
-    <source
-      type="image/png"
-      media="(max-width: 767px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona-movil.avif?alt=media&token=0085aaff-80de-4260-9a36-12412ae77b4c
-      "
-      width="333"
-      height="270"
-    />
     <!-- persona defecto -->
     <img
       src="https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona.webp?alt=media&token=8d98ef71-c9b8-4357-8093-ba9cf0aaa2e8"

--- a/packages/ui-alquicarros/app/components/Images/Video.vue
+++ b/packages/ui-alquicarros/app/components/Images/Video.vue
@@ -1,15 +1,5 @@
 <template>
   <picture>
-    <!-- video avif -->
-    <source
-      type="image/avif"
-      media="(min-width: 768px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fvideo.webp?alt=media&token=424d037e-4aab-47ef-af6f-0fa0caa24e7f
-      "
-      width="2000"
-      height="1620"
-    />
     <!-- video avif movil -->
     <source
       type="image/avif"

--- a/packages/ui-alquilame/app/components/Images/Persona.vue
+++ b/packages/ui-alquilame/app/components/Images/Persona.vue
@@ -30,36 +30,6 @@
       width="2000"
       height="1620"
     />
-    <!-- persona webp movil -->
-    <source
-      type="image/webp"
-      media="(max-width: 767px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona-movil.avif?alt=media&token=0085aaff-80de-4260-9a36-12412ae77b4c
-      "
-      width="333"
-      height="270"
-    />
-    <!-- persona png -->
-    <source
-      type="image/png"
-      media="(min-width: 768px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona.webp?alt=media&token=8d98ef71-c9b8-4357-8093-ba9cf0aaa2e8
-      "
-      width="2000"
-      height="1620"
-    />
-    <!-- persona movil png -->
-    <source
-      type="image/png"
-      media="(max-width: 767px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona-movil.avif?alt=media&token=0085aaff-80de-4260-9a36-12412ae77b4c
-      "
-      width="333"
-      height="270"
-    />
     <!-- persona defecto -->
     <img
       src="https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona.webp?alt=media&token=8d98ef71-c9b8-4357-8093-ba9cf0aaa2e8"

--- a/packages/ui-alquilame/app/components/Images/Video.vue
+++ b/packages/ui-alquilame/app/components/Images/Video.vue
@@ -1,15 +1,5 @@
 <template>
   <picture>
-    <!-- video avif -->
-    <source
-      type="image/avif"
-      media="(min-width: 768px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fvideo.webp?alt=media&token=424d037e-4aab-47ef-af6f-0fa0caa24e7f
-      "
-      width="2000"
-      height="1620"
-    />
     <!-- video avif movil -->
     <source
       type="image/avif"

--- a/packages/ui-alquilatucarro/app/components/Images/Persona.vue
+++ b/packages/ui-alquilatucarro/app/components/Images/Persona.vue
@@ -30,36 +30,6 @@
       width="2000"
       height="1620"
     />
-    <!-- persona webp movil -->
-    <source
-      type="image/webp"
-      media="(max-width: 767px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona-movil.avif?alt=media&token=0085aaff-80de-4260-9a36-12412ae77b4c
-      "
-      width="333"
-      height="270"
-    />
-    <!-- persona png -->
-    <source
-      type="image/png"
-      media="(min-width: 768px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona.webp?alt=media&token=8d98ef71-c9b8-4357-8093-ba9cf0aaa2e8
-      "
-      width="2000"
-      height="1620"
-    />
-    <!-- persona movil png -->
-    <source
-      type="image/png"
-      media="(max-width: 767px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona-movil.avif?alt=media&token=0085aaff-80de-4260-9a36-12412ae77b4c
-      "
-      width="333"
-      height="270"
-    />
     <!-- persona defecto -->
     <img
       src="https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fpersona.webp?alt=media&token=8d98ef71-c9b8-4357-8093-ba9cf0aaa2e8"

--- a/packages/ui-alquilatucarro/app/components/Images/Video.vue
+++ b/packages/ui-alquilatucarro/app/components/Images/Video.vue
@@ -1,15 +1,5 @@
 <template>
   <picture>
-    <!-- video avif -->
-    <source
-      type="image/avif"
-      media="(min-width: 768px)"
-      srcset="
-        https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Fvideo.webp?alt=media&token=424d037e-4aab-47ef-af6f-0fa0caa24e7f
-      "
-      width="2000"
-      height="1620"
-    />
     <!-- video avif movil -->
     <source
       type="image/avif"


### PR DESCRIPTION
## Summary

- **SEO HTML semantics**: Replace invalid `<div>` inside `<h2>` with `<span>` elements across video section, city pages, blog and gana pages. Fix FAQ accordion to use `<span>` instead of headings inside buttons
- **Image sources**: Remove broken `<picture>` `<source>` elements where `type` attribute didn't match actual file format (copy-paste errors serving .webp as AVIF, .avif as WebP/PNG)
- **Search page**: Fix canonical URL to point to city page instead of `/buscar-vehiculos`
- **Category selection**: Prevent page re-mount loop when selecting vehicle category via deep-link
- **Blog content**: Move content files to package root for Nuxt Content v3 compatibility

## Test plan

- [ ] Verify homepage renders correctly on all 3 brands (alquicarros, alquilame, alquilatucarro)
- [ ] Validate HTML with W3C validator — no nested heading/div errors in H2 elements
- [ ] Check city pages FAQ accordion renders valid HTML (span inside button, not h3)
- [ ] Confirm image loading works on Video and Persona sections (AVIF/WebP negotiation)
- [ ] Test category deep-linking: navigate to `/categoria/[code]` and verify no re-mount loop
- [ ] Run Lighthouse SEO audit on homepage — no heading semantic warnings