### PR TITLE
fix(css): correct city buttons desktop width via CSS cascade order

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,7 +43,6 @@ export default defineNuxtConfig({
             .w-2\\.5 { width: 0.625rem; } .h-2\\.5 { height: 0.625rem; }
             .w-4 { width: 1rem; } .h-4 { height: 1rem; }
             .w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
-            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } .md\\:text-base { font-size: 1rem; line-height: 1.5rem; } .md\\:w-fit { width: fit-content; } .md\\:flex-row { flex-direction: row; } .md\\:flex-wrap { flex-wrap: wrap; } }
             .mx-auto { margin-left: auto; margin-right: auto; }
             @media (min-width: 768px) { header .md\\:hidden { display: none !important; } header .md\\:flex { display: flex !important; } }
             @media (max-width: 767px) { header .hidden { display: none !important; } }
@@ -409,6 +408,16 @@ export default defineNuxtConfig({
             .duration-500 { transition-duration: 500ms; }
             .space-y-4 > :not([hidden]) ~ :not([hidden]) { margin-top: 1rem; }
             .placeholder-gray-400::placeholder { color: #9ca3af; }
+            /* Responsive overrides — MUST come after base utilities (.flex-col, .w-full) to win cascade */
+            @media (min-width: 768px) {
+              .md\\:w-4 { width: 1rem; }
+              .md\\:h-4 { height: 1rem; }
+              .md\\:text-base { font-size: 1rem; line-height: 1.5rem; }
+              .md\\:w-fit { width: fit-content; }
+              .md\\:flex-row { flex-direction: row; }
+              .md\\:flex-wrap { flex-wrap: wrap; }
+              .md\\:gap-3 { gap: 0.75rem; }
+            }
           `,
         },
       ],


### PR DESCRIPTION
## Summary
- City buttons in the "Ciudades donde ofrecemos alquiler de carros" section rendered at 100% width on desktop instead of `fit-content`
- Root cause: CSS cascade order — `md:flex-row`, `md:w-fit` were defined **before** `.flex-col`, `.w-full` in critical inline CSS, so base utilities won
- Moved the `@media (min-width: 768px)` responsive block to the **end** of the critical CSS so responsive variants correctly override base utilities
- Added missing `md:gap-3` to the responsive block

## Test plan
- [ ] Verify city buttons display as `width: fit-content` (wrapped in rows) on desktop (≥768px)
- [ ] Verify city buttons remain `width: 100%` (stacked) on mobile (<768px)
- [ ] Verify no CLS regression (PageSpeed Insights)
- [ ] Verify star icons and other `md:` utilities still work correctly