### PR TITLE
chore: trigger deploy for CSS cascade fix

### DIFF
--- a/packages/ui-alquilatucarro/package.json
+++ b/packages/ui-alquilatucarro/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Frontend de Alquilatucarro",
+  "description": "Frontend de Alquilatucarro - alquilatucarro.com",
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",


### PR DESCRIPTION
## Summary
- Trivial change to `packages/ui-alquilatucarro/package.json` to trigger the deploy pipeline
- The CSS cascade fix from PR #107 (`nuxt.config.ts`) was not deployed because `deploy.yml` brand detection only watches `packages/` directories
- This ensures the city buttons desktop width fix reaches production

## Context
- PR #107 merged the actual fix (moving responsive `@media` block to end of critical CSS)
- `deploy.yml` detected `Brands to deploy: []` because `nuxt.config.ts` is root-level