### PR TITLE
fix(alquilatucarro): apply CSS cascade, robots and llms fixes to correct package config

### DIFF
--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -37,7 +37,6 @@ export default defineNuxtConfig({
             .w-2\\.5 { width: 0.625rem; } .h-2\\.5 { height: 0.625rem; }
             .w-4 { width: 1rem; } .h-4 { height: 1rem; }
             .w-5 { width: 1.25rem; } .h-5 { height: 1.25rem; }
-            @media (min-width: 768px) { .md\\:w-4 { width: 1rem; } .md\\:h-4 { height: 1rem; } .md\\:text-base { font-size: 1rem; line-height: 1.5rem; } .md\\:w-fit { width: fit-content; } .md\\:flex-row { flex-direction: row; } .md\\:flex-wrap { flex-wrap: wrap; } }
             .mx-auto { margin-left: auto; margin-right: auto; }
             @media (min-width: 768px) { header .md\\:hidden { display: none !important; } header .md\\:flex { display: flex !important; } }
             @media (max-width: 767px) { header .hidden { display: none !important; } }
@@ -403,6 +402,16 @@ export default defineNuxtConfig({
             .duration-500 { transition-duration: 500ms; }
             .space-y-4 > :not([hidden]) ~ :not([hidden]) { margin-top: 1rem; }
             .placeholder-gray-400::placeholder { color: #9ca3af; }
+            /* Responsive overrides — MUST come after base utilities (.flex-col, .w-full) to win cascade */
+            @media (min-width: 768px) {
+              .md\\:w-4 { width: 1rem; }
+              .md\\:h-4 { height: 1rem; }
+              .md\\:text-base { font-size: 1rem; line-height: 1.5rem; }
+              .md\\:w-fit { width: fit-content; }
+              .md\\:flex-row { flex-direction: row; }
+              .md\\:flex-wrap { flex-wrap: wrap; }
+              .md\\:gap-3 { gap: 0.75rem; }
+            }
           `,
         },
       ],
@@ -627,30 +636,22 @@ export default defineNuxtConfig({
 
   robots: {
     blockNonSeoBots: false,
-    disallow: ['/seo', '/seo/*'],
-    allow: [
-      '/',
-      '/armenia',
-      '/barranquilla',
-      '/bogota',
-      '/bucaramanga',
-      '/cali',
-      '/cartagena',
-      '/cucuta',
-      '/ibague',
-      '/manizales',
-      '/medellin',
-      '/monteria',
-      '/neiva',
-      '/pereira',
-      '/santa-marta',
-      '/valledupar',
-      '/villavicencio',
-      '/floridablanca',
-      '/palmira',
-      '/soledad',
-      '/blog',
-      '/blog/*',
+    groups: [
+      {
+        userAgent: ['*'],
+        allow: ['/'],
+        disallow: ['/seo', '/seo/*'],
+      },
+      // Bots de búsqueda IA — permitidos (generan tráfico referido)
+      {
+        userAgent: ['OAI-SearchBot', 'PerplexityBot', 'Applebot-Extended'],
+        allow: ['/'],
+      },
+      // Bots de entrenamiento IA — bloqueados (consumen sin retorno)
+      {
+        userAgent: ['GPTBot', 'Google-Extended', 'CCBot', 'Bytespider', 'Amazonbot'],
+        disallow: ['/'],
+      },
     ],
     sitemap: "/sitemap.xml"
   },
@@ -658,8 +659,24 @@ export default defineNuxtConfig({
   llms: {
     domain: 'https://alquilatucarro.com',
     title: 'Alquilatucarro',
-    description: 'Los mejores precios en alquiler de carros y alquiler de camionetas en varias zonas del país. Reserva Ahora! Tenemos variedad de carros nuevos renovando nuestra flota cada 2 años. Alquiler de carros en Bogotá, Medellín, Barranquilla, Cali, Cartagena, Bucaramanga, Ibagué, Manizales, Cúcuta, Santa Marta, Pereira, Montería y Villavicencio.',
+    description: 'Plataforma colombiana de reservas de alquiler de carros. Conectamos viajeros con rentadoras verificadas en 19 ciudades de Colombia. Reserva online sin anticipos, con descuentos de hasta 60% y recogida en aeropuerto. Operamos como intermediario digital (AMAW SAS), no como rentadora directa.',
     sections: [
+      {
+        title: 'Servicios',
+        description: 'Qué ofrecemos como plataforma de reservas',
+        links: [
+          {
+            title: 'Reserva de carros',
+            description: 'Reserva online sin anticipos. Compactos, sedanes, SUVs y camionetas. Recogida en aeropuerto o sucursal. Descuentos hasta 60% por reserva anticipada.',
+            href: 'https://alquilatucarro.com',
+          },
+          {
+            title: 'Blog de viajes',
+            description: 'Guías de viaje por Colombia: requisitos de alquiler, pico y placa, rutas, tips para familias y destinos recomendados.',
+            href: 'https://alquilatucarro.com/blog',
+          },
+        ],
+      },
       {
         title: 'Lugares',
         description: 'Ciudades de Colombia donde se presta el servicio de alquiler de carros',
@@ -667,97 +684,97 @@ export default defineNuxtConfig({
           {
             title: 'Armenia',
             description: '¿Planeas visitar Armenia? En Alquilatucarro Armenia puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto El Edén. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como Salento, Filandia o el Parque del Café. Nuestra sede en Armenia te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en el corazón del Paisaje Cultural Cafetero, declarado Patrimonio de la Humanidad!',
-            href: '/armenia',
+            href: 'https://alquilatucarro.com/armenia',
           },
           {
             title: 'Barranquilla',
             description: '¿Planeas visitar Barranquilla? En Alquilatucarro Barranquilla puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Ernesto Cortissoz. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Malecón del Río, el Museo del Caribe o el Zoológico de Barranquilla. Nuestra sede en Barranquilla te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Puerta de Oro de Colombia, epicentro del Carnaval más famoso del país!',
-            href: '/barranquilla',
+            href: 'https://alquilatucarro.com/barranquilla',
           },
           {
             title: 'Bogotá',
             description: '¿Planeas visitar Bogotá? En Alquilatucarro Bogotá puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto El Dorado. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Museo del Oro, el Cerro de Monserrate o la Zona Rosa. Nuestra sede en Bogotá te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la capital a 2.600 metros más cerca de las estrellas!',
-            href: '/bogota',
+            href: 'https://alquilatucarro.com/bogota',
           },
           {
             title: 'Bucaramanga',
             description: '¿Planeas visitar Bucaramanga? En Alquilatucarro Bucaramanga puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Palonegro. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Parque Nacional del Chicamocha, el Ecoparque Cerro del Santísimo o el centro histórico. Nuestra sede en Bucaramanga te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad Bonita de Colombia, famosa por sus parques y aventura extrema!',
-            href: '/bucaramanga',
+            href: 'https://alquilatucarro.com/bucaramanga',
           },
           {
             title: 'Cali',
             description: '¿Planeas visitar Cali? En Alquilatucarro Cali puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Alfonso Bonilla Aragón. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Zoológico de Cali, la Iglesia La Ermita o el Cristo Rey. Nuestra sede en Cali te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la capital mundial de la salsa, donde el ritmo nunca para!',
-            href: '/cali',
+            href: 'https://alquilatucarro.com/cali',
           },
           {
             title: 'Cartagena',
             description: '¿Planeas visitar Cartagena? En Alquilatucarro Cartagena puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Rafael Núñez. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Castillo de San Felipe, el Centro Histórico o las Islas del Rosario. Nuestra sede en Cartagena te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Heroica, joya colonial del Caribe!',
-            href: '/cartagena',
+            href: 'https://alquilatucarro.com/cartagena',
           },
           {
             title: 'Cúcuta',
             description: '¿Planeas visitar Cúcuta? En Alquilatucarro Cúcuta puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Camilo Daza. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Malecón, el Parque Santander o el Puente Internacional Simón Bolívar. Nuestra sede en Cúcuta te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Perla del Norte, puerta fronteriza con Venezuela!',
-            href: '/cucuta',
+            href: 'https://alquilatucarro.com/cucuta',
           },
           {
             title: 'Ibagué',
             description: '¿Planeas visitar Ibagué? En Alquilatucarro Ibagué puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Perales. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Cañón del Combeima, el Jardín Botánico San Jorge o el Conservatorio del Tolima. Nuestra sede en Ibagué te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Capital Musical de Colombia, cuna de festivales folclóricos!',
-            href: '/ibague',
+            href: 'https://alquilatucarro.com/ibague',
           },
           {
             title: 'Manizales',
             description: '¿Planeas visitar Manizales? En Alquilatucarro Manizales puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto La Nubia. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como la Catedral Basílica, el Ecoparque Los Yarumos o el Nevado del Ruiz. Nuestra sede en Manizales te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad de las Puertas Abiertas, entre volcanes y café!',
-            href: '/manizales',
+            href: 'https://alquilatucarro.com/manizales',
           },
           {
             title: 'Medellín',
             description: '¿Planeas visitar Medellín? En Alquilatucarro Medellín puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto José María Córdova. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Parque Arví, la Comuna 13 o el Jardín Botánico. Nuestra sede en Medellín te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad de la Eterna Primavera, ejemplo de innovación urbana!',
-            href: '/medellin',
+            href: 'https://alquilatucarro.com/medellin',
           },
           {
             title: 'Montería',
             description: '¿Planeas visitar Montería? En Alquilatucarro Montería puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Los Garzones. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Río Sinú, el Parque Ronda del Sinú o el Sombrero Vueltiao. Nuestra sede en Montería te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Perla del Sinú, capital ganadera del Caribe!',
-            href: '/monteria',
+            href: 'https://alquilatucarro.com/monteria',
           },
           {
             title: 'Neiva',
             description: '¿Planeas visitar Neiva? En Alquilatucarro Neiva puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Benito Salas. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Desierto de la Tatacoa, el Parque Andino o el Festival del Bambuco. Nuestra sede en Neiva te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Puerta del Sur, cerca de maravillas arqueológicas!',
-            href: '/neiva',
+            href: 'https://alquilatucarro.com/neiva',
           },
           {
             title: 'Pereira',
             description: '¿Planeas visitar Pereira? En Alquilatucarro Pereira puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Matecaña. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Bioparque Ukumarí, el Santuario de Fauna y Flora Otún Quimbaya o el Cerrito. Nuestra sede en Pereira te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Querendona, Trasnochadora y Morena del Eje Cafetero!',
-            href: '/pereira',
+            href: 'https://alquilatucarro.com/pereira',
           },
           {
             title: 'Santa Marta',
             description: '¿Planeas visitar Santa Marta? En Alquilatucarro Santa Marta puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Simón Bolívar. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Parque Tayrona, la Quinta de San Pedro Alejandrino o Taganga. Nuestra sede en Santa Marta te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Bahía Más Linda de América!',
-            href: '/santa-marta',
+            href: 'https://alquilatucarro.com/santa-marta',
           },
           {
             title: 'Valledupar',
             description: '¿Planeas visitar Valledupar? En Alquilatucarro Valledupar puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Alfonso López. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Río Guatapurí, la Plaza Alfonso López o el Festival Vallenato. Nuestra sede en Valledupar te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Cuna del Vallenato, tierra de acordeones y leyendas!',
-            href: '/valledupar',
+            href: 'https://alquilatucarro.com/valledupar',
           },
           {
             title: 'Villavicencio',
             description: '¿Planeas visitar Villavicencio? En Alquilatucarro Villavicencio puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Vanguardia. Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Bioparque Los Ocarros, el Mirador de Buenavista o Caño Cristales (cerca). Nuestra sede en Villavicencio te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Puerta al Llano, con sabores de llanero auténtico!',
-            href: '/villavicencio',
+            href: 'https://alquilatucarro.com/villavicencio',
           },
           {
             title: 'Floridablanca',
             description: '¿Planeas visitar Floridablanca? En Alquilatucarro Floridablanca puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Palonegro (Bucaramanga). Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Ecoparque Cerro El Santísimo, el Jardín Botánico Eloy Valenzuela o Cañón del Chicamocha. Nuestra sede en Floridablanca te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Ciudad Dulce de Colombia, famosa por sus obleas!',
-            href: '/floridablanca',
+            href: 'https://alquilatucarro.com/floridablanca',
           },
           {
             title: 'Palmira',
             description: '¿Planeas visitar Palmira? En Alquilatucarro Palmira puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Alfonso Bonilla Aragón (Cali). Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Lago Calima, el Parque del Azúcar o el centro histórico. Nuestra sede en Palmira te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en la Villa de las Palmas, corazón agrícola del Valle!',
-            href: '/palmira',
+            href: 'https://alquilatucarro.com/palmira',
           },
           {
             title: 'Soledad',
             description: '¿Planeas visitar Soledad? En Alquilatucarro Soledad puedes reservar en línea sin anticipos y recoger directamente en el Aeropuerto Ernesto Cortissoz (Barranquilla). Aprovecha descuentos de hasta el 60% por reserva anticipada y elige entre carros compactos, sedanes o camionetas para recorrer lugares como el Malecón del Río, el Parque Sagrado Corazón o el Museo del Carnaval. Nuestra sede en Soledad te ofrece precios bajos y disponibilidad inmediata los 7 días de la semana. ¡Alquila fácil, sin trámites largos y comienza tu aventura en el municipio más poblado del Atlántico, vibrante y carnavalero!',
-            href: '/soledad',
+            href: 'https://alquilatucarro.com/soledad',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- PR #106 (robots/llms) and PR #107 (CSS cascade) were applied to the root `nuxt.config.ts`, but the build uses `packages/ui-alquilatucarro/nuxt.config.ts`
- This PR applies all three fixes to the correct package-level config file:
  - **CSS cascade fix**: Moved responsive `@media (min-width: 768px)` block to end of critical CSS so `md:flex-row`, `md:w-fit` win over `.flex-col`, `.w-full` in the cascade
  - **robots.txt**: Updated from flat allow/disallow to user-agent groups (AI search bots allowed, training bots blocked)
  - **llms.txt**: Improved description, added "Servicios" section, converted to absolute URLs

## Test plan
- [ ] Verify city buttons display in a row on desktop (md:flex-row wins cascade)
- [ ] Verify city buttons display as column on mobile (flex-col still applies)
- [ ] Check /robots.txt shows AI bot groups
- [ ] Check /llms.txt shows updated description and absolute URLs