### PR TITLE
fix: remove dead santamarta ID mapping workarounds

### DIFF
--- a/packages/ui-alquicarros/app/components/CityPage.vue
+++ b/packages/ui-alquicarros/app/components/CityPage.vue
@@ -399,13 +399,8 @@ const props = defineProps<{
   city: City;
 }>();
 
-// Filter branches for current city (handle ID mapping inconsistencies)
-const cityIdMapping: Record<string, string> = {
-  'santamarta': 'santa-marta',
-};
-const branchCityId = cityIdMapping[props.city?.id] || props.city?.id;
 const cityBranches = computed(() =>
-  branches.filter((branch: { city: string }) => branch.city === branchCityId)
+  branches.filter((branch: { city: string }) => branch.city === props.city?.id)
 );
 
 const testimonios: Testimonial[] | undefined = props.city?.testimonials;

--- a/packages/ui-alquicarros/app/layouts/default.vue
+++ b/packages/ui-alquicarros/app/layouts/default.vue
@@ -190,23 +190,15 @@ const reservationEndDay = today(defaultTimezone).add({ days: 8 }).toString();
 const reservationInitHour = "12:00";
 const reservationEndHour = "12:00";
 
-// Mapeo de IDs de ciudad que difieren entre cities y branches
-const cityIdMapping: Record<string, string> = {
-  'santamarta': 'santa-marta',
-};
-
 const getCityReservationURL = (city: CityData): string => {
-  // Normalizar el ID de la ciudad (manejar inconsistencias como santamarta vs santa-marta)
-  const branchCityId = cityIdMapping[city.id] || city.id;
-
   // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
   const airportBranch = branches.find(
-    (branch: BranchData) => branch.city === branchCityId && branch.code.startsWith('AA')
+    (branch: BranchData) => branch.city === city.id && branch.code.startsWith('AA')
   );
 
   // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
   const branch = airportBranch || branches.find(
-    (branch: BranchData) => branch.city === branchCityId
+    (branch: BranchData) => branch.city === city.id
   );
 
   if (!branch) {

--- a/packages/ui-alquilame/app/components/CityPage.vue
+++ b/packages/ui-alquilame/app/components/CityPage.vue
@@ -399,13 +399,8 @@ const props = defineProps<{
   city: City;
 }>();
 
-// Filter branches for current city (handle ID mapping inconsistencies)
-const cityIdMapping: Record<string, string> = {
-  'santamarta': 'santa-marta',
-};
-const branchCityId = cityIdMapping[props.city?.id] || props.city?.id;
 const cityBranches = computed(() =>
-  branches.filter((branch: { city: string }) => branch.city === branchCityId)
+  branches.filter((branch: { city: string }) => branch.city === props.city?.id)
 );
 
 const testimonios: Testimonial[] | undefined = props.city?.testimonials;

--- a/packages/ui-alquilame/app/layouts/default.vue
+++ b/packages/ui-alquilame/app/layouts/default.vue
@@ -190,23 +190,15 @@ const reservationEndDay = today(defaultTimezone).add({ days: 8 }).toString();
 const reservationInitHour = "12:00";
 const reservationEndHour = "12:00";
 
-// Mapeo de IDs de ciudad que difieren entre cities y branches
-const cityIdMapping: Record<string, string> = {
-  'santamarta': 'santa-marta',
-};
-
 const getCityReservationURL = (city: CityData): string => {
-  // Normalizar el ID de la ciudad (manejar inconsistencias como santamarta vs santa-marta)
-  const branchCityId = cityIdMapping[city.id] || city.id;
-
   // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
   const airportBranch = branches.find(
-    (branch: BranchData) => branch.city === branchCityId && branch.code.startsWith('AA')
+    (branch: BranchData) => branch.city === city.id && branch.code.startsWith('AA')
   );
 
   // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
   const branch = airportBranch || branches.find(
-    (branch: BranchData) => branch.city === branchCityId
+    (branch: BranchData) => branch.city === city.id
   );
 
   if (!branch) {

--- a/packages/ui-alquilatucarro/app/components/CityPage.vue
+++ b/packages/ui-alquilatucarro/app/components/CityPage.vue
@@ -396,13 +396,8 @@ const props = defineProps<{
   city: City;
 }>();
 
-// Filter branches for current city (handle ID mapping inconsistencies)
-const cityIdMapping: Record<string, string> = {
-  'santamarta': 'santa-marta',
-};
-const branchCityId = cityIdMapping[props.city?.id] || props.city?.id;
 const cityBranches = computed(() =>
-  branches.filter((branch: { city: string }) => branch.city === branchCityId)
+  branches.filter((branch: { city: string }) => branch.city === props.city?.id)
 );
 
 const testimonios: Testimonial[] | undefined = props.city?.testimonials;

--- a/packages/ui-alquilatucarro/app/layouts/default.vue
+++ b/packages/ui-alquilatucarro/app/layouts/default.vue
@@ -190,23 +190,15 @@ const reservationEndDay = today(defaultTimezone).add({ days: 8 }).toString();
 const reservationInitHour = "12:00";
 const reservationEndHour = "12:00";
 
-// Mapeo de IDs de ciudad que difieren entre cities y branches
-const cityIdMapping: Record<string, string> = {
-  'santamarta': 'santa-marta',
-};
-
 const getCityReservationURL = (city: CityData): string => {
-  // Normalizar el ID de la ciudad (manejar inconsistencias como santamarta vs santa-marta)
-  const branchCityId = cityIdMapping[city.id] || city.id;
-
   // Buscar la sucursal de aeropuerto para esta ciudad (código empieza con "AA")
   const airportBranch = branches.find(
-    (branch: BranchData) => branch.city === branchCityId && branch.code.startsWith('AA')
+    (branch: BranchData) => branch.city === city.id && branch.code.startsWith('AA')
   );
 
   // Si no hay aeropuerto, buscar cualquier sucursal de esa ciudad
   const branch = airportBranch || branches.find(
-    (branch: BranchData) => branch.city === branchCityId
+    (branch: BranchData) => branch.city === city.id
   );
 
   if (!branch) {


### PR DESCRIPTION
## Summary
- Removes dead `cityIdMapping` workaround code from 6 files across 3 brand packages
- All configs (`cities.config.ts`, `branches.config.ts`, `admin.config.ts`) consistently use `"santa-marta"` (with hyphen)
- The mapping `'santamarta' → 'santa-marta'` was never triggered at runtime since no source generates `"santamarta"`
- Net cleanup: **-39 lines** (9 added, 48 removed)

## Files changed
- `packages/ui-alquilatucarro/app/layouts/default.vue` — removed mapping + simplified branch lookup
- `packages/ui-alquicarros/app/layouts/default.vue` — same
- `packages/ui-alquilame/app/layouts/default.vue` — same
- `packages/ui-alquilatucarro/app/components/CityPage.vue` — removed mapping + direct city.id usage
- `packages/ui-alquicarros/app/components/CityPage.vue` — same
- `packages/ui-alquilame/app/components/CityPage.vue` — same

## Test plan
- [ ] CI passes (builds all 3 brands)
- [ ] Santa Marta city page loads correctly and shows branches
- [ ] Other city pages unaffected