### PR TITLE
fix(css): resolve UModal double-translate centering bug

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
@@ -419,6 +419,23 @@ header [data-highlighted],
     right: auto !important;
 }
 
+/* Fix: UModal centering — Tailwind v4/v3 double-translate conflict */
+/* The dialog gets BOTH `translate: -50% -50%` (v4 individual prop) AND */
+/* `transform: translate(-50%, -50%)` (v3 compat), causing 2x shift off-center. */
+/* Fix: Replace translate centering with inset + margin auto (transform-independent). */
+[role="dialog"][class*="top-1/2"][class*="left-1/2"] {
+    top: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    margin: auto !important;
+    translate: none !important;
+    --tw-translate-x: 0 !important;
+    --tw-translate-y: 0 !important;
+    width: fit-content !important;
+    height: fit-content !important;
+}
+
 /* UModal customization - remove header divider and reduce spacing */
 [role="dialog"] [data-slot="header"] {
     border-bottom: none !important;

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
@@ -419,6 +419,23 @@ header [data-highlighted],
     right: auto !important;
 }
 
+/* Fix: UModal centering — Tailwind v4/v3 double-translate conflict */
+/* The dialog gets BOTH `translate: -50% -50%` (v4 individual prop) AND */
+/* `transform: translate(-50%, -50%)` (v3 compat), causing 2x shift off-center. */
+/* Fix: Replace translate centering with inset + margin auto (transform-independent). */
+[role="dialog"][class*="top-1/2"][class*="left-1/2"] {
+    top: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    margin: auto !important;
+    translate: none !important;
+    --tw-translate-x: 0 !important;
+    --tw-translate-y: 0 !important;
+    width: fit-content !important;
+    height: fit-content !important;
+}
+
 /* UModal customization - remove header divider and reduce spacing */
 [role="dialog"] [data-slot="header"] {
     border-bottom: none !important;

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -419,6 +419,23 @@ header [data-highlighted],
     right: auto !important;
 }
 
+/* Fix: UModal centering — Tailwind v4/v3 double-translate conflict */
+/* The dialog gets BOTH `translate: -50% -50%` (v4 individual prop) AND */
+/* `transform: translate(-50%, -50%)` (v3 compat), causing 2x shift off-center. */
+/* Fix: Replace translate centering with inset + margin auto (transform-independent). */
+[role="dialog"][class*="top-1/2"][class*="left-1/2"] {
+    top: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    margin: auto !important;
+    translate: none !important;
+    --tw-translate-x: 0 !important;
+    --tw-translate-y: 0 !important;
+    width: fit-content !important;
+    height: fit-content !important;
+}
+
 /* UModal customization - remove header divider and reduce spacing */
 [role="dialog"] [data-slot="header"] {
     border-bottom: none !important;


### PR DESCRIPTION
## Summary
- Tailwind v4 individual `translate` property and v3 compat `transform: translate()` were both applied to modal dialogs, causing a 2x shift off-center (modal appeared in upper-left on desktop)
- Replaced translate-based centering with `inset: 0; margin: auto` approach, which is transform-independent and allows the `scale-in` animation to work without position conflicts
- Applied fix to all 3 brand packages (alquilatucarro, alquilame, alquicarros)

## Test plan
- [x] Verified modal centering via browser injection: center X=768, Y=348 matches viewport center exactly
- [x] Confirmed selector `[class*="top-1/2"][class*="left-1/2"]` only targets modals, not slideover dialogs
- [ ] Verify on production after deploy: click "?" icon next to Seguro Básico on any vehicle search results page
- [ ] Verify slideover menu still works correctly on mobile