### PR TITLE
fix(carousel): restore desktop arrow buttons hidden by Tailwind v4 scanner

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
@@ -539,3 +539,24 @@ section[id] > [data-slot="container"] {
         padding-bottom: 4rem !important;
     }
 }
+
+/* Fix: UCarousel arrows — Tailwind v4 scanner doesn't detect responsive */
+/* classes (hidden, lg:block) passed dynamically through :ui prop string. */
+/* Handle arrow visibility and button styling via explicit CSS. */
+[data-slot="arrows"] {
+    display: none !important;
+}
+
+@media (min-width: 1024px) {
+    [data-slot="arrows"] {
+        display: block !important;
+    }
+
+    [data-slot="arrows"] button {
+        cursor: pointer;
+        border-radius: 0.75rem;
+        height: 3rem;
+        border: none;
+        box-shadow: none;
+    }
+}

--- a/packages/ui-alquicarros/app/components/Carrusel.vue
+++ b/packages/ui-alquicarros/app/components/Carrusel.vue
@@ -9,10 +9,7 @@
       :ui="{
         viewport: 'rounded-t-lg',
         dots: 'bottom-5 gap-1',
-        dot: 'size-2 bg-gray-400/70 rounded-full transition-all duration-300 data-[state=active]:w-6 data-[state=active]:bg-white',
-        arrows: 'hidden lg:block',
-        prev: 'translate-x-[200%] cursor-pointer rounded-xl h-12 border-0',
-        next: '-translate-x-[200%] cursor-pointer rounded-xl h-12 border-0'
+        dot: 'size-2 bg-gray-400/70 rounded-full transition-all duration-300 data-[state=active]:w-6 data-[state=active]:bg-white'
       }"
     >
       <div class="relative">

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
@@ -539,3 +539,24 @@ section[id] > [data-slot="container"] {
         padding-bottom: 4rem !important;
     }
 }
+
+/* Fix: UCarousel arrows — Tailwind v4 scanner doesn't detect responsive */
+/* classes (hidden, lg:block) passed dynamically through :ui prop string. */
+/* Handle arrow visibility and button styling via explicit CSS. */
+[data-slot="arrows"] {
+    display: none !important;
+}
+
+@media (min-width: 1024px) {
+    [data-slot="arrows"] {
+        display: block !important;
+    }
+
+    [data-slot="arrows"] button {
+        cursor: pointer;
+        border-radius: 0.75rem;
+        height: 3rem;
+        border: none;
+        box-shadow: none;
+    }
+}

--- a/packages/ui-alquilame/app/components/Carrusel.vue
+++ b/packages/ui-alquilame/app/components/Carrusel.vue
@@ -9,10 +9,7 @@
       :ui="{
         viewport: 'rounded-t-lg',
         dots: 'bottom-5 gap-1',
-        dot: 'size-2 bg-gray-400/70 rounded-full transition-all duration-300 data-[state=active]:w-6 data-[state=active]:bg-white',
-        arrows: 'hidden lg:block',
-        prev: 'translate-x-[200%] cursor-pointer rounded-xl h-12 border-0',
-        next: '-translate-x-[200%] cursor-pointer rounded-xl h-12 border-0'
+        dot: 'size-2 bg-gray-400/70 rounded-full transition-all duration-300 data-[state=active]:w-6 data-[state=active]:bg-white'
       }"
     >
       <div class="relative">

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -539,3 +539,24 @@ section[id] > [data-slot="container"] {
         padding-bottom: 4rem !important;
     }
 }
+
+/* Fix: UCarousel arrows — Tailwind v4 scanner doesn't detect responsive */
+/* classes (hidden, lg:block) passed dynamically through :ui prop string. */
+/* Handle arrow visibility and button styling via explicit CSS. */
+[data-slot="arrows"] {
+    display: none !important;
+}
+
+@media (min-width: 1024px) {
+    [data-slot="arrows"] {
+        display: block !important;
+    }
+
+    [data-slot="arrows"] button {
+        cursor: pointer;
+        border-radius: 0.75rem;
+        height: 3rem;
+        border: none;
+        box-shadow: none;
+    }
+}

--- a/packages/ui-alquilatucarro/app/components/Carrusel.vue
+++ b/packages/ui-alquilatucarro/app/components/Carrusel.vue
@@ -9,10 +9,7 @@
       :ui="{
         viewport: 'rounded-t-lg',
         dots: 'bottom-5 gap-1',
-        dot: 'size-2 bg-gray-400/70 rounded-full transition-all duration-300 data-[state=active]:w-6 data-[state=active]:bg-white',
-        arrows: 'hidden lg:block',
-        prev: 'translate-x-[200%] cursor-pointer rounded-xl h-12 border-0',
-        next: '-translate-x-[200%] cursor-pointer rounded-xl h-12 border-0'
+        dot: 'size-2 bg-gray-400/70 rounded-full transition-all duration-300 data-[state=active]:w-6 data-[state=active]:bg-white'
       }"
     >
       <div class="relative">


### PR DESCRIPTION
## Summary
- Carousel prev/next arrow buttons were invisible on all screen sizes since the monorepo migration
- **Root cause**: Tailwind v4 content scanner doesn't detect responsive classes (`hidden`, `lg:block`, `translate-x-[200%]`) passed dynamically via `:ui` prop strings — the CSS rules were never generated
- **Fix**: Move arrow visibility from `:ui` prop to explicit CSS in `base.css` with `@media (min-width: 1024px)` media query
- Applied identically across all 3 brand packages (alquilatucarro, alquilame, alquicarros)

## Changes
- **Carrusel.vue** (x3): Removed non-functional `arrows`, `prev`, `next` entries from `:ui` prop
- **base.css** (x3): Added `[data-slot="arrows"]` rules — `display: none` by default, `display: block` at lg breakpoint, plus button styling (cursor, border-radius, height, no border/shadow)

## Test plan
- [x] Injected CSS fix in live Barranquilla page — arrows appeared correctly on all carousels
- [x] Verified arrows are properly positioned (left/right edges of each carousel)
- [x] Confirmed `display: block` at 1536px viewport width
- [ ] Verify post-deploy on alquilatucarro.com search results page
- [ ] Verify arrows hidden on mobile viewport