### PR TITLE
fix(css): position carousel arrows inside card boundaries

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/base.css
@@ -541,8 +541,8 @@ section[id] > [data-slot="container"] {
 }
 
 /* Fix: UCarousel arrows — Tailwind v4 scanner doesn't detect responsive */
-/* classes (hidden, lg:block) passed dynamically through :ui prop string. */
-/* Handle arrow visibility and button styling via explicit CSS. */
+/* classes (hidden, lg:block, translate) passed dynamically via :ui prop. */
+/* Handle arrow visibility, positioning and styling via explicit CSS. */
 [data-slot="arrows"] {
     display: none !important;
 }
@@ -554,9 +554,33 @@ section[id] > [data-slot="container"] {
 
     [data-slot="arrows"] button {
         cursor: pointer;
-        border-radius: 0.75rem;
-        height: 3rem;
+        border-radius: 9999px;
+        width: 2.5rem;
+        height: 2.5rem;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(0, 0, 0, 0.45);
+        color: white;
         border: none;
         box-shadow: none;
+        --tw-ring-color: transparent;
+        --tw-ring-shadow: none;
+        z-index: 10;
+    }
+
+    [data-slot="arrows"] button:hover {
+        background-color: rgba(0, 0, 0, 0.65);
+    }
+
+    [data-slot="arrows"] button:first-child {
+        inset-inline-start: 0.5rem;
+        inset-inline-end: auto;
+    }
+
+    [data-slot="arrows"] button:last-child {
+        inset-inline-start: auto;
+        inset-inline-end: 0.5rem;
     }
 }

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/base.css
@@ -541,8 +541,8 @@ section[id] > [data-slot="container"] {
 }
 
 /* Fix: UCarousel arrows — Tailwind v4 scanner doesn't detect responsive */
-/* classes (hidden, lg:block) passed dynamically through :ui prop string. */
-/* Handle arrow visibility and button styling via explicit CSS. */
+/* classes (hidden, lg:block, translate) passed dynamically via :ui prop. */
+/* Handle arrow visibility, positioning and styling via explicit CSS. */
 [data-slot="arrows"] {
     display: none !important;
 }
@@ -554,9 +554,33 @@ section[id] > [data-slot="container"] {
 
     [data-slot="arrows"] button {
         cursor: pointer;
-        border-radius: 0.75rem;
-        height: 3rem;
+        border-radius: 9999px;
+        width: 2.5rem;
+        height: 2.5rem;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(0, 0, 0, 0.45);
+        color: white;
         border: none;
         box-shadow: none;
+        --tw-ring-color: transparent;
+        --tw-ring-shadow: none;
+        z-index: 10;
+    }
+
+    [data-slot="arrows"] button:hover {
+        background-color: rgba(0, 0, 0, 0.65);
+    }
+
+    [data-slot="arrows"] button:first-child {
+        inset-inline-start: 0.5rem;
+        inset-inline-end: auto;
+    }
+
+    [data-slot="arrows"] button:last-child {
+        inset-inline-start: auto;
+        inset-inline-end: 0.5rem;
     }
 }

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -541,8 +541,8 @@ section[id] > [data-slot="container"] {
 }
 
 /* Fix: UCarousel arrows — Tailwind v4 scanner doesn't detect responsive */
-/* classes (hidden, lg:block) passed dynamically through :ui prop string. */
-/* Handle arrow visibility and button styling via explicit CSS. */
+/* classes (hidden, lg:block, translate) passed dynamically via :ui prop. */
+/* Handle arrow visibility, positioning and styling via explicit CSS. */
 [data-slot="arrows"] {
     display: none !important;
 }
@@ -554,9 +554,33 @@ section[id] > [data-slot="container"] {
 
     [data-slot="arrows"] button {
         cursor: pointer;
-        border-radius: 0.75rem;
-        height: 3rem;
+        border-radius: 9999px;
+        width: 2.5rem;
+        height: 2.5rem;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background-color: rgba(0, 0, 0, 0.45);
+        color: white;
         border: none;
         box-shadow: none;
+        --tw-ring-color: transparent;
+        --tw-ring-shadow: none;
+        z-index: 10;
+    }
+
+    [data-slot="arrows"] button:hover {
+        background-color: rgba(0, 0, 0, 0.65);
+    }
+
+    [data-slot="arrows"] button:first-child {
+        inset-inline-start: 0.5rem;
+        inset-inline-end: auto;
+    }
+
+    [data-slot="arrows"] button:last-child {
+        inset-inline-start: auto;
+        inset-inline-end: 0.5rem;
     }
 }


### PR DESCRIPTION
## Summary
- Override UCarousel default `inset-inline-start` values that placed prev/next buttons outside the card area (-48px left, +16px right overflow)
- Arrows now render as 40px circular semi-transparent buttons positioned 0.5rem from each card edge
- Applied identically across all 3 brand packages (alquilatucarro, alquilame, alquicarros)

## Root cause
Nuxt UI v4 UCarousel default theme uses negative `inset-inline-start` values to position arrow buttons outside the carousel viewport. The previous PR #115 made arrows visible but didn't override positioning.

## Test plan
- [ ] Verify arrows appear inside card boundaries on desktop (≥1024px)
- [ ] Verify arrows are hidden on mobile (<1024px)
- [ ] Verify prev/next navigation works on all 3 carousels
- [ ] Verify hover effect (darker background) works