### PR TITLE
fix(css): add chevron rotation animation to collapsible accordions

### DIFF
--- a/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquicarros/app/assets/css/rentacar-main/category.css
@@ -42,6 +42,19 @@
       @apply flex justify-between items-center w-full px-4 py-3 text-left transition-all focus:outline-none text-gray-700 bg-white hover:bg-white cursor-pointer;
     }
 
+    /* Chevron rotation animation on collapsible open/close. */
+    /* :ui.trailingIcon classes don't apply to custom #trailing slots, */
+    /* so we handle the animation via CSS on the parent button state. */
+    .boton-contenedor-descripcion-carro svg,
+    .boton-contenedor-adicionales-carro svg {
+      transition: transform 200ms ease-out;
+    }
+
+    .boton-contenedor-descripcion-carro[data-state="open"] svg,
+    .boton-contenedor-adicionales-carro[data-state="open"] svg {
+      transform: rotate(180deg);
+    }
+
     .categoria-carro {
       @apply font-light text-lg leading-tight block;
     }

--- a/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilame/app/assets/css/rentacar-main/category.css
@@ -42,6 +42,19 @@
       @apply flex justify-between items-center w-full px-4 py-3 text-left transition-all focus:outline-none text-gray-700 bg-white hover:bg-white cursor-pointer;
     }
 
+    /* Chevron rotation animation on collapsible open/close. */
+    /* :ui.trailingIcon classes don't apply to custom #trailing slots, */
+    /* so we handle the animation via CSS on the parent button state. */
+    .boton-contenedor-descripcion-carro svg,
+    .boton-contenedor-adicionales-carro svg {
+      transition: transform 200ms ease-out;
+    }
+
+    .boton-contenedor-descripcion-carro[data-state="open"] svg,
+    .boton-contenedor-adicionales-carro[data-state="open"] svg {
+      transform: rotate(180deg);
+    }
+
     .categoria-carro {
       @apply font-light text-lg leading-tight block;
     }

--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/category.css
@@ -42,6 +42,19 @@
       @apply flex justify-between items-center w-full px-4 py-3 text-left transition-all focus:outline-none text-gray-700 bg-white hover:bg-white cursor-pointer;
     }
 
+    /* Chevron rotation animation on collapsible open/close. */
+    /* :ui.trailingIcon classes don't apply to custom #trailing slots, */
+    /* so we handle the animation via CSS on the parent button state. */
+    .boton-contenedor-descripcion-carro svg,
+    .boton-contenedor-adicionales-carro svg {
+      transition: transform 200ms ease-out;
+    }
+
+    .boton-contenedor-descripcion-carro[data-state="open"] svg,
+    .boton-contenedor-adicionales-carro[data-state="open"] svg {
+      transform: rotate(180deg);
+    }
+
     .categoria-carro {
       @apply font-light text-lg leading-tight block;
     }


### PR DESCRIPTION
## Summary
- Add 180° rotation animation to chevron icons when collapsible accordions open/close
- Affects both accordions per card: category description and additional services
- Applied identically across all 3 brand packages

## Root cause
`UButton` `:ui.trailingIcon` classes (`group-data-[state=open]:rotate-180 transition-transform duration-200`) only apply to the default trailing icon element, **not** to custom `#trailing` template slots. Since `CategoryCard.vue` uses `<template #trailing><ChevronDownIcon /></template>`, those classes never reached the SVG.

## Fix
CSS rules targeting `button[data-state="open"] svg` to rotate the chevron 180° with a 200ms ease-out transition.

## Test plan
- [ ] Click category description accordion — chevron rotates up on open, down on close
- [ ] Click "Servicios adicionales" accordion — same rotation behavior
- [ ] Animation is smooth (200ms transition)