### PR TITLE
fix(pricing): total price now updates when switching insurance type

### DIFF
--- a/packages/ui-alquicarros/app/components/CategoryCard.vue
+++ b/packages/ui-alquicarros/app/components/CategoryCard.vue
@@ -88,7 +88,7 @@
               IVA: $ {{ ivaFeePriceTooltip }} <br />
               Total: $ {{ actualTotalPriceTooltip }} <br />
             </template>
-            <ULink raw class="precio-total"> $ <span v-once>{{currencyTotalPrice}}</span></ULink>
+            <ULink raw class="precio-total"> $ <span>{{currencyTotalPrice}}</span></ULink>
           </UTooltip>
 
           <!-- <div class="font-bold text-xl" style="white-space: nowrap;" v-text="currencyTotalPrice"></div> -->

--- a/packages/ui-alquilame/app/components/CategoryCard.vue
+++ b/packages/ui-alquilame/app/components/CategoryCard.vue
@@ -88,7 +88,7 @@
               IVA: $ {{ ivaFeePriceTooltip }} <br />
               Total: $ {{ actualTotalPriceTooltip }} <br />
             </template>
-            <ULink raw class="precio-total"> $ <span v-once>{{currencyTotalPrice}}</span></ULink>
+            <ULink raw class="precio-total"> $ <span>{{currencyTotalPrice}}</span></ULink>
           </UTooltip>
 
           <!-- <div class="font-bold text-xl" style="white-space: nowrap;" v-text="currencyTotalPrice"></div> -->

--- a/packages/ui-alquilatucarro/app/components/CategoryCard.vue
+++ b/packages/ui-alquilatucarro/app/components/CategoryCard.vue
@@ -88,7 +88,7 @@
               IVA: $ {{ ivaFeePriceTooltip }} <br />
               Total: $ {{ actualTotalPriceTooltip }} <br />
             </template>
-            <ULink raw class="precio-total"> $ <span v-once>{{currencyTotalPrice}}</span></ULink>
+            <ULink raw class="precio-total"> $ <span>{{currencyTotalPrice}}</span></ULink>
           </UTooltip>
 
           <!-- <div class="font-bold text-xl" style="white-space: nowrap;" v-text="currencyTotalPrice"></div> -->


### PR DESCRIPTION
## Summary
- Remove `v-once` from `currencyTotalPrice` span in CategoryCard.vue
- Total price now recalculates reactively when switching between Seguro Básico and Seguro Total

## Root cause
`v-once` directive (added in commit `18a1984`) rendered the total price only once and blocked Vue reactivity updates. Daily rate updated correctly (no `v-once`) but the total stayed frozen.

## Test plan
- [ ] Select Seguro Básico — note daily rate and total
- [ ] Switch to Seguro Total — both daily rate AND total should update
- [ ] Switch back to Seguro Básico — both values revert
- [ ] Verify on multiple vehicle categories