### PR TITLE
fix(reservation): import validation schemas as values instead of types

### DIFF
--- a/packages/ui-alquicarros/app/components/ReservationForm.vue
+++ b/packages/ui-alquicarros/app/components/ReservationForm.vue
@@ -92,9 +92,9 @@
 </template>
 
 <script setup lang="ts">
-import type {
-  ReservationFormValidationSchemaType,
-  ReservationWithFlightFormValidationSchemaType,
+import {
+  ReservationFormValidationSchema,
+  ReservationWithFlightFormValidationSchema,
 } from '@rentacar-main/logic/utils';
 
 // Lazy load vue-tel-input (solo se carga cuando se renderiza el formulario)

--- a/packages/ui-alquilame/app/components/ReservationForm.vue
+++ b/packages/ui-alquilame/app/components/ReservationForm.vue
@@ -92,9 +92,9 @@
 </template>
 
 <script setup lang="ts">
-import type {
-  ReservationFormValidationSchemaType,
-  ReservationWithFlightFormValidationSchemaType,
+import {
+  ReservationFormValidationSchema,
+  ReservationWithFlightFormValidationSchema,
 } from '@rentacar-main/logic/utils';
 
 // Lazy load vue-tel-input (solo se carga cuando se renderiza el formulario)

--- a/packages/ui-alquilatucarro/app/components/ReservationForm.vue
+++ b/packages/ui-alquilatucarro/app/components/ReservationForm.vue
@@ -92,9 +92,9 @@
 </template>
 
 <script setup lang="ts">
-import type {
-  ReservationFormValidationSchemaType,
-  ReservationWithFlightFormValidationSchemaType,
+import {
+  ReservationFormValidationSchema,
+  ReservationWithFlightFormValidationSchema,
 } from '@rentacar-main/logic/utils';
 
 // Lazy load vue-tel-input (solo se carga cuando se renderiza el formulario)


### PR DESCRIPTION
## Summary
- **Bug**: El formulario de datos de reserva ("Datos para reservas") estaba completamente vacío — sin campos de nombre, email, teléfono, etc.
- **Causa raíz**: `ReservationForm.vue` importaba `ReservationFormValidationSchemaType` y `ReservationWithFlightFormValidationSchemaType` con `import type` (solo tipos TypeScript), pero el código en runtime usa `ReservationFormValidationSchema` y `ReservationWithFlightFormValidationSchema` (valores). Los `import type` se eliminan en compilación → `ReferenceError` en runtime → crash en `setup()` → formulario no se renderiza.
- **Fix**: Cambiar `import type { ...Type }` por `import { ... }` importando los valores reales de validación.
- **Afecta**: Los 3 packages (alquilatucarro, alquilame, alquicarros)

## Error en consola
```
ReferenceError: ReservationFormValidationSchema is not defined
    at setup (ReservationForm.vue)
```

## Test plan
- [ ] Abrir búsqueda de vehículos en cualquier ciudad
- [ ] Click "Solicitar este vehículo" en cualquier tarjeta
- [ ] Verificar que el slideover "Resumen de la reserva" se muestre
- [ ] Click "Siguiente" para abrir "Datos para reservas"
- [ ] Verificar que los campos del formulario se rendericen (nombre, apellidos, ID, email, teléfono, checkbox)
- [ ] Llenar formulario y verificar que "Solicitar reserva" funcione