### PR TITLE
fix(blog): avatar SSR hydration race condition (#123)

### DIFF
--- a/packages/ui-alquilatucarro/app/pages/blog/[...slug].vue
+++ b/packages/ui-alquilatucarro/app/pages/blog/[...slug].vue
@@ -471,6 +471,12 @@ function updateReadingProgress() {
 onMounted(() => {
   window.addEventListener('scroll', updateReadingProgress, { passive: true })
   updateReadingProgress()
+
+  // Check if avatar failed before Vue hydration (SSR race condition)
+  const avatarImg = document.querySelector('img.rounded-full[loading="lazy"]') as HTMLImageElement
+  if (avatarImg && avatarImg.complete && avatarImg.naturalWidth === 0) {
+    avatarError.value = true
+  }
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
## Summary

- **Problem**: Avatar `@error` handler fires before Vue hydrates the SSR-rendered HTML, so the reactive fallback (red circle with initial) never activates. The broken image icon shows instead.
- **Fix**: Added `onMounted` check that inspects `img.complete && naturalWidth === 0` to detect pre-hydration failures and set `avatarError = true`.

## Test plan

- [ ] Hard-refresh a blog article page
- [ ] Verify avatar shows red circle with "A" initial instead of broken image icon
- [ ] Verify both hero avatar (8x8) and bio avatar (20x20) show fallback