### PR TITLE
fix(blog): restore ToC visibility on desktop (#125)

### DIFF
--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -584,3 +584,15 @@ section[id] > [data-slot="container"] {
         inset-inline-end: 0.5rem;
     }
 }
+
+/* Fix: Blog ToC — Tailwind v4 scanner doesn't generate lg:block */
+/* when combined with hidden in template. Hide on mobile, show on desktop. */
+[data-blog-toc] {
+    display: none;
+}
+
+@media (min-width: 1024px) {
+    [data-blog-toc] {
+        display: block;
+    }
+}

--- a/packages/ui-alquilatucarro/app/pages/blog/[...slug].vue
+++ b/packages/ui-alquilatucarro/app/pages/blog/[...slug].vue
@@ -90,7 +90,7 @@
           <aside class="lg:w-1/3">
             <div class="sticky top-24 space-y-8">
               <!-- Table of Contents -->
-              <nav v-if="post.body?.toc?.links?.length" class="hidden lg:block bg-gray-50 rounded-xl p-4">
+              <nav v-if="post.body?.toc?.links?.length" data-blog-toc class="bg-gray-50 rounded-xl p-4">
                 <h3 class="font-bold text-gray-900 mb-3">Contenido</h3>
                 <ul class="space-y-2">
                   <li v-for="link in post.body.toc.links" :key="link.id">


### PR DESCRIPTION
## Summary
- **Problem**: Tailwind v4 scanner does not generate `lg:block` when combined with `hidden` in Vue templates. The Table of Contents was invisible on desktop (`display: none` at all breakpoints).
- **Solution**: Replace `hidden lg:block` with `data-blog-toc` attribute + explicit CSS media query (same pattern as PR #115 for carousel arrows).
- **Files**: `[...slug].vue` (template), `base.css` (+10 lines)

## Test plan
- [ ] Verify ToC is visible on desktop (≥1024px)
- [ ] Verify ToC is hidden on mobile (<1024px)
- [ ] Verify ToC shows only h2 links (no h3 sub-items)