### PR TITLE
feat(tarifas): add monthly rates page and teaser CTA

### DIFF
--- a/packages/logic/src/config/index.ts
+++ b/packages/logic/src/config/index.ts
@@ -19,3 +19,4 @@ export {
   type VehicleModel,
   type MonthPrice,
 } from './admin.config';
+export { tarifasConfig, type TarifaGama, type TarifaPlan, type TarifasConfig } from './tarifas.config';

--- a/packages/logic/src/config/tarifas.config.ts
+++ b/packages/logic/src/config/tarifas.config.ts
@@ -1,0 +1,120 @@
+/**
+ * Monthly rental rates configuration (Persona Natural)
+ * Updated manually when the rental company sends new rate tables
+ */
+
+export interface TarifaPlan {
+  daily: number;
+  monthly: number;
+}
+
+export interface TarifaGama {
+  code: string;
+  name: string;
+  kmExtra: number;
+  plan1k: TarifaPlan;
+  plan2k: TarifaPlan;
+}
+
+export interface TarifasConfig {
+  period: {
+    start: string;
+    end: string;
+    label: string;
+  };
+  gamas: TarifaGama[];
+}
+
+export const tarifasConfig: TarifasConfig = {
+  period: {
+    start: '2026-02-01',
+    end: '2026-03-31',
+    label: '1 Feb – 31 Mar 2026',
+  },
+  gamas: [
+    {
+      code: 'C',
+      name: 'Económico',
+      kmExtra: 700,
+      plan1k: { daily: 114833, monthly: 3445000 },
+      plan2k: { daily: 128300, monthly: 3849000 },
+    },
+    {
+      code: 'F',
+      name: 'Sedán Mecánico',
+      kmExtra: 700,
+      plan1k: { daily: 136600, monthly: 4098000 },
+      plan2k: { daily: 150100, monthly: 4503000 },
+    },
+    {
+      code: 'FX',
+      name: 'Sedán Automático',
+      kmExtra: 700,
+      plan1k: { daily: 141100, monthly: 4233000 },
+      plan2k: { daily: 154600, monthly: 4638000 },
+    },
+    {
+      code: 'FL',
+      name: 'Compacto Híbrido',
+      kmExtra: 700,
+      plan1k: { daily: 171533, monthly: 5146000 },
+      plan2k: { daily: 185033, monthly: 5551000 },
+    },
+    {
+      code: 'FU',
+      name: 'Sedán Full',
+      kmExtra: 700,
+      plan1k: { daily: 181200, monthly: 5436000 },
+      plan2k: { daily: 194700, monthly: 5841000 },
+    },
+    {
+      code: 'GC',
+      name: 'Camioneta',
+      kmExtra: 900,
+      plan1k: { daily: 181567, monthly: 5447000 },
+      plan2k: { daily: 201267, monthly: 6038000 },
+    },
+    {
+      code: 'G4',
+      name: 'Camioneta 4x4',
+      kmExtra: 900,
+      plan1k: { daily: 197467, monthly: 5924000 },
+      plan2k: { daily: 217167, monthly: 6515000 },
+    },
+    {
+      code: 'GL',
+      name: 'Camioneta Full',
+      kmExtra: 900,
+      plan1k: { daily: 208533, monthly: 6256000 },
+      plan2k: { daily: 228233, monthly: 6847000 },
+    },
+    {
+      code: 'LE',
+      name: 'Camioneta Especial',
+      kmExtra: 1100,
+      plan1k: { daily: 213367, monthly: 6401000 },
+      plan2k: { daily: 254533, monthly: 7636000 },
+    },
+    {
+      code: 'LU',
+      name: 'Camioneta Lujo',
+      kmExtra: 1100,
+      plan1k: { daily: 228367, monthly: 6851000 },
+      plan2k: { daily: 269533, monthly: 8086000 },
+    },
+    {
+      code: 'GR',
+      name: 'Camioneta 7 Puestos',
+      kmExtra: 1100,
+      plan1k: { daily: 325400, monthly: 9762000 },
+      plan2k: { daily: 366567, monthly: 10997000 },
+    },
+    {
+      code: 'GY',
+      name: 'Premium',
+      kmExtra: 1100,
+      plan1k: { daily: 466833, monthly: 14005000 },
+      plan2k: { daily: 508000, monthly: 15240000 },
+    },
+  ],
+};

--- a/packages/ui-alquilatucarro/app/components/CityPage.vue
+++ b/packages/ui-alquilatucarro/app/components/CityPage.vue
@@ -166,6 +166,9 @@
       </div>
     </section>
 
+    <!-- Monthly Rates Teaser -->
+    <MonthlyRatesTeaser />
+
     <!-- Delivery Points Section -->
     <section v-if="cityBranches.length > 0" id="puntos-entrega" class="bg-gray-50 text-black py-8 md:py-12 px-4 md:px-8">
       <div class="max-w-5xl mx-auto text-center">

--- a/packages/ui-alquilatucarro/app/components/MonthlyRatesTeaser.vue
+++ b/packages/ui-alquilatucarro/app/components/MonthlyRatesTeaser.vue
@@ -1,0 +1,32 @@
+<template>
+  <section class="bg-gradient-to-r from-[#0B1A2E] to-[#162d4a] text-white py-8 md:py-10 px-4 md:px-8">
+    <div class="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+      <div class="text-center sm:text-left">
+        <h3 class="text-lg md:text-xl font-bold">
+          Arriendos mensuales desde
+          <span class="text-green-400">{{ formatCOP(minDaily) }}/día</span>
+        </h3>
+        <p class="text-white/60 text-sm mt-1">
+          Planes de 1.000 y 2.000 kms · IVA y seguro incluidos
+        </p>
+      </div>
+      <NuxtLink
+        to="/tarifas"
+        class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-600 text-white font-bold text-sm px-6 py-2.5 rounded-lg transition-colors shrink-0"
+      >
+        Ver tarifas
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" /></svg>
+      </NuxtLink>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { tarifasConfig } from '@rentacar-main/logic/config';
+
+const minDaily = tarifasConfig.gamas[0].plan1k.daily;
+
+function formatCOP(value: number): string {
+  return '$' + value.toLocaleString('es-CO');
+}
+</script>

--- a/packages/ui-alquilatucarro/app/components/SelectBranch.vue
+++ b/packages/ui-alquilatucarro/app/components/SelectBranch.vue
@@ -62,8 +62,10 @@ import {
 /** props */
 const props = withDefaults(defineProps<{
   variant?: 'white' | 'gray'
+  rentalDays?: number
 }>(), {
-  variant: 'white'
+  variant: 'white',
+  rentalDays: 7,
 });
 
 /** consts */
@@ -73,7 +75,7 @@ const reservationInitDay: string = today(defaultTimezone)
   .add({ days: 1 })
   .toString();
 const reservationEndDay: string = today(defaultTimezone)
-  .add({ days: 8 })
+  .add({ days: 1 + props.rentalDays })
   .toString();
 const reservationInitHour: string = "12:00";
 const reservationEndHour: string = "12:00";

--- a/packages/ui-alquilatucarro/app/pages/tarifas.vue
+++ b/packages/ui-alquilatucarro/app/pages/tarifas.vue
@@ -1,0 +1,198 @@
+<template>
+  <div class="bg-white min-h-screen">
+    <!-- Header -->
+    <div class="text-center pt-9 pb-3 px-6 md:pt-12">
+      <h1 class="text-2xl md:text-3xl font-extrabold uppercase text-[#0B1A2E]">
+        Tarifas <span class="text-red-600">Mensuales</span>
+      </h1>
+      <span class="inline-block mt-2 text-gray-500 text-sm">
+        {{ tarifasConfig.period.label }}
+      </span>
+    </div>
+
+    <!-- Intro -->
+    <p class="max-w-[700px] mx-auto text-center text-gray-600 text-sm leading-relaxed px-6 mt-4">
+      Arriendos mensuales para persona natural. Todas las tarifas incluyen IVA, seguro de protección y mantenimiento preventivo.
+    </p>
+
+    <!-- Plan toggle -->
+    <div class="flex justify-center gap-1 mx-auto mt-5 mb-4 bg-gray-200 rounded-[10px] p-1 w-fit">
+      <button
+        :class="[
+          'px-5 py-2 rounded-lg text-sm font-semibold transition-all duration-200',
+          activePlan === '1k'
+            ? 'bg-green-700 text-white shadow-[0_3px_10px_rgba(21,128,61,0.3)]'
+            : 'bg-transparent text-gray-400'
+        ]"
+        @click="activePlan = '1k'"
+      >
+        1.000 kms
+      </button>
+      <button
+        :class="[
+          'px-5 py-2 rounded-lg text-sm font-semibold transition-all duration-200',
+          activePlan === '2k'
+            ? 'bg-green-700 text-white shadow-[0_3px_10px_rgba(21,128,61,0.3)]'
+            : 'bg-transparent text-gray-400'
+        ]"
+        @click="activePlan = '2k'"
+      >
+        2.000 kms
+      </button>
+    </div>
+
+    <!-- Table -->
+    <div class="max-w-[900px] mx-auto px-5 pb-10 overflow-x-auto">
+      <table class="w-full border-separate border-spacing-0 rounded-xl overflow-hidden text-sm bg-white shadow-[0_1px_3px_rgba(0,0,0,0.06),0_4px_16px_rgba(0,0,0,0.04)]">
+        <thead>
+          <tr>
+            <th class="bg-gray-50 text-gray-400 text-[0.7rem] font-semibold uppercase tracking-wider px-2.5 sm:px-4 py-3 text-left border-b border-gray-100">Gama</th>
+            <th class="bg-gray-50 text-gray-400 text-[0.7rem] font-semibold uppercase tracking-wider px-2.5 sm:px-4 py-3 text-right border-b border-gray-100">Tarifa / día</th>
+            <th class="bg-gray-50 text-gray-400 text-[0.7rem] font-semibold uppercase tracking-wider px-2.5 sm:px-4 py-3 text-right border-b border-gray-100">Total mes</th>
+            <th class="bg-gray-50 text-gray-400 text-[0.7rem] font-semibold uppercase tracking-wider px-2.5 sm:px-4 py-3 text-center border-b border-gray-100">Km extra</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="gama in tarifasConfig.gamas"
+            :key="gama.code"
+            class="transition-colors hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
+          >
+            <!-- Gama -->
+            <td class="px-2.5 sm:px-4 py-3 align-middle">
+              <div class="flex items-center gap-2.5">
+                <span
+                  class="w-2 h-2 rounded-full shrink-0"
+                  :class="tierDotClass(gama.kmExtra)"
+                />
+                <div>
+                  <div class="font-bold text-[0.95rem] text-gray-900">{{ gama.code }}</div>
+                  <div class="text-[0.7rem] text-gray-400 font-medium">{{ gama.name }}</div>
+                </div>
+              </div>
+            </td>
+            <!-- Tarifa/día -->
+            <td class="px-2.5 sm:px-4 py-3 align-middle text-right font-extrabold text-[1.05rem] text-[#0B1A2E] whitespace-nowrap">
+              {{ formatCOP(planData(gama).daily) }}
+            </td>
+            <!-- Total mes -->
+            <td class="px-2.5 sm:px-4 py-3 align-middle text-right font-medium text-gray-400 text-[0.85rem] whitespace-nowrap">
+              {{ formatCOP(planData(gama).monthly) }}
+            </td>
+            <!-- Km extra -->
+            <td class="px-2.5 sm:px-4 py-3 align-middle text-center">
+              <span class="inline-block bg-gray-100 px-2.5 py-0.5 rounded-md text-[0.78rem] font-semibold text-gray-500 whitespace-nowrap">
+                {{ formatCOP(gama.kmExtra) }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Availability note -->
+    <div class="max-w-[900px] mx-auto px-5 pb-6">
+      <div class="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 text-sm text-amber-900">
+        <p class="font-semibold mb-1">Gama GR — Camioneta 7 Puestos</p>
+        <p class="text-amber-800 leading-relaxed">
+          Sujeta a disponibilidad. Debe solicitarse con anticipación.
+          Disponible solo en <strong>Bogotá</strong>, <strong>Cali</strong>, <strong>Cartagena</strong>, <strong>Rionegro</strong> y <strong>Medellín</strong>.
+        </p>
+      </div>
+    </div>
+
+    <!-- CTA: branch selector for monthly rental -->
+    <div class="max-w-[440px] mx-auto px-5 pb-10">
+      <p class="text-center text-black text-lg font-bold mb-3">
+        Cotiza tu arriendo mensual
+      </p>
+      <SelectBranch variant="gray" :rental-days="30" />
+    </div>
+
+    <!-- FAQs -->
+    <section class="bg-gray-100 py-10 px-4">
+      <div class="max-w-[700px] mx-auto">
+        <h2 class="text-2xl md:text-3xl font-bold text-center mb-6">
+          <span class="text-red-700">Preguntas frecuentes</span> <span class="text-black">sobre mensualidades</span>
+        </h2>
+        <UAccordion :items="faqs" :ui="faqUI" class="space-y-2">
+          <template #default="{ item }">
+            <span class="block text-base font-medium text-gray-800 px-4" v-text="item.label" />
+          </template>
+          <template #content="{ item }">
+            <span class="block text-base text-gray-600 py-3 bg-gray-50 px-4 rounded-lg" v-text="item.content" />
+          </template>
+        </UAccordion>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { tarifasConfig } from '@rentacar-main/logic/config';
+import type { TarifaGama } from '@rentacar-main/logic/config';
+
+const { franchise } = useAppConfig();
+
+const activePlan = ref<'1k' | '2k'>('1k');
+
+function planData(gama: TarifaGama) {
+  return activePlan.value === '1k' ? gama.plan1k : gama.plan2k;
+}
+
+function formatCOP(value: number): string {
+  return '$ ' + value.toLocaleString('es-CO');
+}
+
+function tierDotClass(kmExtra: number): string {
+  if (kmExtra <= 700) return 'bg-green-500';
+  if (kmExtra <= 900) return 'bg-amber-500';
+  return 'bg-blue-500';
+}
+
+const faqs = [
+  {
+    label: '¿Qué documentos necesito para un arriendo mensual?',
+    content: 'Necesitas licencia de conducción vigente, tarjeta de crédito a nombre del conductor con cupo disponible, y ser mayor de 18 años. La tarjeta de crédito es obligatoria para el depósito de garantía.',
+  },
+  {
+    label: '¿Qué tipo de seguro incluye la tarifa?',
+    content: 'Todas las tarifas incluyen seguro básico contra daños y robo con deducible. El seguro cubre daños al vehículo por accidente y pérdida total. No cubre accesorios removibles (radio, espejos, copas) ni multas de tránsito.',
+  },
+  {
+    label: '¿Qué pasa si me paso del kilometraje contratado?',
+    content: 'Se cobra un recargo por cada kilómetro adicional según la gama del vehículo. Puedes ver la tarifa de km extra en la tabla de arriba. También puedes contratar el plan de 2.000 kms si necesitas recorrer más distancia.',
+  },
+  {
+    label: '¿Qué pasa si necesito el vehículo por más de 30 días?',
+    content: 'Cada reserva cubre un período máximo de 30 días. Si necesitas más tiempo, puedes hacer reservas adicionales. Por ejemplo, para 45 días puedes hacer una reserva mensual (30 días) y otra por los 15 días restantes, eligiendo tarifa diaria o mensual según te convenga más.',
+  },
+  {
+    label: '¿Puedo renovar mi arriendo mensual?',
+    content: 'Sí, al finalizar tu período de 30 días puedes hacer una nueva reserva por otro mes completo o por los días adicionales que necesites.',
+  },
+  {
+    label: '¿Puedo cancelar o devolver antes el vehículo?',
+    content: 'Sí, puedes devolver el vehículo antes de la fecha pactada. Ten en cuenta que la tarifa mensual corresponde al período completo de 30 días y no aplican reembolsos por días no utilizados.',
+  },
+];
+
+const faqUI = {
+  item: 'bg-white rounded-lg mb-2 px-2 pb-2 !border-0 !border-b-0',
+  body: '!border-none',
+  trailingIcon: 'mr-2 transition-transform duration-200',
+};
+
+useHead({
+  title: 'Tarifas Mensuales Alquiler de Carros',
+  link: [
+    { rel: 'canonical', href: `${franchise.website}/tarifas` },
+  ],
+});
+
+useSeoMeta({
+  description: `Tarifas mensuales para alquiler de carros en Colombia desde $${tarifasConfig.gamas[0].plan1k.monthly.toLocaleString('es-CO')}/mes. Planes de 1.000 y 2.000 kms con IVA y seguro incluidos.`,
+  ogTitle: 'Tarifas Mensuales Alquiler de Carros | Alquilatucarro',
+  ogDescription: `Arriendos mensuales desde $${tarifasConfig.gamas[0].plan1k.monthly.toLocaleString('es-CO')}/mes. Compara precios de 12 categorías de vehículos.`,
+});
+</script>


### PR DESCRIPTION
## Summary
- New `/tarifas` page with monthly rental rates for 12 vehicle tiers (Feb-Mar 2026), plan toggle (1,000/2,000 kms), availability note for Gama GR, branch selector CTA, and 6 FAQs
- New `MonthlyRatesTeaser` component inserted in all 19 city pages showing minimum daily rate with link to `/tarifas`
- `SelectBranch` now accepts configurable `rentalDays` prop (default 7; tarifas page uses 30)

## Test plan
- [ ] Navigate to `/tarifas` — verify table renders 12 gamas with correct pricing
- [ ] Toggle between 1,000 and 2,000 kms — verify prices update
- [ ] Verify GR availability note renders in amber box below table
- [ ] Select a city in CTA — verify it opens reservation with 30-day range
- [ ] Navigate to any city page (e.g. `/bogota`) — verify MonthlyRatesTeaser appears between Benefits and Delivery Points
- [ ] Click "Ver tarifas" in teaser — verify navigation to `/tarifas`
- [ ] Test mobile responsive layout on `/tarifas`