### PR TITLE
feat(home): add monthly rates teaser to homepage

### DIFF
--- a/packages/ui-alquilatucarro/app/pages/index.vue
+++ b/packages/ui-alquilatucarro/app/pages/index.vue
@@ -202,6 +202,9 @@
       </template>
     </UPageSection>
 
+    <!-- Monthly Rates Teaser -->
+    <MonthlyRatesTeaser />
+
     <!-- Testimonials Section -->
     <section id="testimonios" class="bg-gray-200 text-black py-12 md:py-20 px-4 md:px-8">
       <div class="max-w-7xl mx-auto">


### PR DESCRIPTION
## Summary
- Add `MonthlyRatesTeaser` component to homepage between vehicle categories and testimonials sections
- Surfaces monthly rental pricing ($114.833/día) with link to `/tarifas` page

## Test plan
- [ ] Verify teaser renders between Categorías and Testimonios on homepage
- [ ] Verify "Ver tarifas" button links to `/tarifas`
- [ ] Check responsive layout on mobile and desktop