### PR TITLE
fix: Defaults conscientes del contexto de ciudad

### DIFF
--- a/e2e/time-format-12h.spec.ts
+++ b/e2e/time-format-12h.spec.ts
@@ -224,24 +224,19 @@ test.describe('Formato 12h en URLs de búsqueda', () => {
 
   test.describe('Regresión - Bug Identificado (Documentado)', () => {
 
-    test.skip('KNOWN BUG: defaults no respetan contexto de ciudad en URL', async ({ page }) => {
+    test('defaults respetan contexto de ciudad en URL', async ({ page }) => {
       /**
-       * Bug identificado durante testing:
-       * Cuando se resetea a defaults por formato inválido, los lugares de
-       * recogida/devolución no respetan el contexto de la ciudad en la URL.
+       * Verifica que cuando se resetea a defaults por formato inválido,
+       * los lugares de recogida/devolución respetan el contexto de ciudad.
        *
-       * Ejemplo: /armenia/... debería usar armenia-aeropuerto como default,
-       * pero usa bogota-aeropuerto.
+       * Fix implementado: useDefaultRouteParams ahora acepta parámetro cityContext
+       * que extraen los middlewares del path de la URL.
        *
-       * Este bug existe ANTES de este requerimiento y debe tratarse en sesión futura.
-       *
-       * Para reproducir:
-       * 1. Navegar a /armenia/buscar-vehiculos/.../hora-recogida/25:00/...
-       * 2. Observar que redirige a bogota-aeropuerto en lugar de armenia-aeropuerto
+       * Ejemplo: /armenia/... usa armenia-aeropuerto como default
        */
       await page.goto('/armenia/buscar-vehiculos/lugar-recogida/armenia-aeropuerto/lugar-devolucion/armenia-aeropuerto/fecha-recogida/2026-02-10/fecha-devolucion/2026-02-17/hora-recogida/25:00/hora-devolucion/13:00');
 
-      // Comportamiento esperado (actualmente falla):
+      // Debe resetear a defaults con contexto de ciudad armenia
       await expect(page).toHaveURL(/lugar-recogida\/armenia-aeropuerto/);
       await expect(page).toHaveURL(/lugar-devolucion\/armenia-aeropuerto/);
     });

--- a/packages/logic/src/composables/useDefaultRouteParams.ts
+++ b/packages/logic/src/composables/useDefaultRouteParams.ts
@@ -4,8 +4,16 @@ import { ref } from 'vue';
 // Internal dependencies - utils
 import { createCurrentDateObject } from '@rentacar-main/logic/utils';
 
-export default function useDefaultRouteParams(){
-    const defaultBranch = 'bogota-aeropuerto'; // Slug for AABOT (Bogotá Aeropuerto)
+/**
+ * Returns default route parameters for search URLs
+ * @param cityContext - Optional city slug to use for location defaults (e.g., "armenia", "medellin")
+ *                      If provided, returns city-specific airport (e.g., "armenia-aeropuerto")
+ *                      If not provided, falls back to global default ("bogota-aeropuerto")
+ */
+export default function useDefaultRouteParams(cityContext?: string){
+    const defaultBranch = cityContext
+        ? `${cityContext}-aeropuerto`
+        : 'bogota-aeropuerto'; // Fallback global default
     const defaultHour = '12:00pm';
     const defaultDaysRange = 7;
 
@@ -13,13 +21,13 @@ export default function useDefaultRouteParams(){
     const nextDay = currentDay.add({ days: 1 });
     const nextWeekDay = nextDay.add({ days: defaultDaysRange });
 
-    const defaultLugarRecogida = ref<string | null>(defaultBranch); // bogota aeropuerto
-    const defaultLugarDevolucion = ref<string | null>(defaultBranch); // bogota aeropuerto
+    const defaultLugarRecogida = ref<string | null>(defaultBranch);
+    const defaultLugarDevolucion = ref<string | null>(defaultBranch);
     const defaultFechaRecogida = ref<string | null>(nextDay.toString());
     const defaultFechaDevolucion = ref<string | null>(nextWeekDay.toString());
     const defaultHoraRecogida = ref<string | null>(defaultHour);
     const defaultHoraDevolucion = ref<string | null>(defaultHour);
-    
+
     return {
         defaultLugarRecogida,
         defaultLugarDevolucion,

--- a/packages/ui-alquicarros/app/middleware/validateSearchParams.ts
+++ b/packages/ui-alquicarros/app/middleware/validateSearchParams.ts
@@ -22,6 +22,11 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const hora_recogida = to.params.hora_recogida as string;
   const hora_devolucion = to.params.hora_devolucion as string;
 
+  // Extract city context from URL path for city-aware defaults
+  // e.g., "/armenia/buscar-vehiculos/..." → cityContext = "armenia"
+  const pathSegments = to.path.split('/').filter(Boolean);
+  const cityContext = pathSegments[0]; // First segment is always the city
+
   // Skip validation if route doesn't have search parameters (e.g., /bogota, /medellin)
   if (!fecha_recogida || !fecha_devolucion || !hora_recogida || !hora_devolucion) {
     return;
@@ -40,7 +45,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
       defaultFechaDevolucion,
       defaultHoraRecogida,
       defaultHoraDevolucion
-    } = useDefaultRouteParams();
+    } = useDefaultRouteParams(cityContext);
 
     to.params.lugar_recogida = defaultLugarRecogida.value as string;
     to.params.lugar_devolucion = defaultLugarDevolucion.value as string;
@@ -96,7 +101,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
         defaultFechaDevolucion,
         defaultHoraRecogida,
         defaultHoraDevolucion
-      } = useDefaultRouteParams();
+      } = useDefaultRouteParams(cityContext);
 
       to.params.lugar_recogida = defaultLugarRecogida.value as string;
       to.params.lugar_devolucion = defaultLugarDevolucion.value as string;
@@ -142,7 +147,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
       defaultFechaDevolucion,
       defaultHoraRecogida,
       defaultHoraDevolucion
-    } = useDefaultRouteParams();
+    } = useDefaultRouteParams(cityContext);
 
     to.params.lugar_recogida = defaultLugarRecogida.value as string;
     to.params.lugar_devolucion = defaultLugarDevolucion.value as string;

--- a/packages/ui-alquilame/app/middleware/validateSearchParams.ts
+++ b/packages/ui-alquilame/app/middleware/validateSearchParams.ts
@@ -24,6 +24,11 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const hora_recogida = to.params.hora_recogida as string;
   const hora_devolucion = to.params.hora_devolucion as string;
 
+  // Extract city context from URL path for city-aware defaults
+  // e.g., "/armenia/buscar-vehiculos/..." → cityContext = "armenia"
+  const pathSegments = to.path.split('/').filter(Boolean);
+  const cityContext = pathSegments[0]; // First segment is always the city
+
   // Skip validation if route doesn't have search parameters (e.g., /bogota, /medellin)
   if (!fecha_recogida || !fecha_devolucion || !hora_recogida || !hora_devolucion) {
     return;
@@ -42,7 +47,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
       defaultFechaDevolucion,
       defaultHoraRecogida,
       defaultHoraDevolucion
-    } = useDefaultRouteParams();
+    } = useDefaultRouteParams(cityContext);
 
     to.params.lugar_recogida = defaultLugarRecogida.value as string;
     to.params.lugar_devolucion = defaultLugarDevolucion.value as string;
@@ -97,7 +102,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
         defaultFechaDevolucion,
         defaultHoraRecogida,
         defaultHoraDevolucion
-      } = useDefaultRouteParams();
+      } = useDefaultRouteParams(cityContext);
 
       to.params.lugar_recogida = defaultLugarRecogida.value as string;
       to.params.lugar_devolucion = defaultLugarDevolucion.value as string;
@@ -143,7 +148,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
       defaultFechaDevolucion,
       defaultHoraRecogida,
       defaultHoraDevolucion
-    } = useDefaultRouteParams();
+    } = useDefaultRouteParams(cityContext);
 
     to.params.lugar_recogida = defaultLugarRecogida.value as string;
     to.params.lugar_devolucion = defaultLugarDevolucion.value as string;

--- a/packages/ui-alquilatucarro/app/middleware/validateSearchParams.ts
+++ b/packages/ui-alquilatucarro/app/middleware/validateSearchParams.ts
@@ -24,6 +24,11 @@ export default defineNuxtRouteMiddleware((to, from) => {
   const hora_recogida = to.params.hora_recogida as string;
   const hora_devolucion = to.params.hora_devolucion as string;
 
+  // Extract city context from URL path for city-aware defaults
+  // e.g., "/armenia/buscar-vehiculos/..." → cityContext = "armenia"
+  const pathSegments = to.path.split('/').filter(Boolean);
+  const cityContext = pathSegments[0]; // First segment is always the city
+
   // Skip validation if route doesn't have search parameters (e.g., /bogota, /medellin)
   if (!fecha_recogida || !fecha_devolucion || !hora_recogida || !hora_devolucion) {
     return;
@@ -42,7 +47,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
       defaultFechaDevolucion,
       defaultHoraRecogida,
       defaultHoraDevolucion
-    } = useDefaultRouteParams();
+    } = useDefaultRouteParams(cityContext);
 
     to.params.lugar_recogida = defaultLugarRecogida.value as string;
     to.params.lugar_devolucion = defaultLugarDevolucion.value as string;
@@ -97,7 +102,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
         defaultFechaDevolucion,
         defaultHoraRecogida,
         defaultHoraDevolucion
-      } = useDefaultRouteParams();
+      } = useDefaultRouteParams(cityContext);
 
       to.params.lugar_recogida = defaultLugarRecogida.value as string;
       to.params.lugar_devolucion = defaultLugarDevolucion.value as string;
@@ -143,7 +148,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
       defaultFechaDevolucion,
       defaultHoraRecogida,
       defaultHoraDevolucion
-    } = useDefaultRouteParams();
+    } = useDefaultRouteParams(cityContext);
 
     to.params.lugar_recogida = defaultLugarRecogida.value as string;
     to.params.lugar_devolucion = defaultLugarDevolucion.value as string;


### PR DESCRIPTION
## Resumen

Corrige bug donde defaults no respetaban contexto de ciudad al resetear parámetros inválidos.

## Problema

Cuando el middleware detectaba parámetros inválidos y reseteaba a defaults, siempre usaba `bogota-aeropuerto` sin importar el contexto de ciudad en la URL.

**Ejemplo del bug:**
```
/armenia/.../hora-recogida/25:00
    ↓ resetea a defaults
/armenia/.../lugar-recogida/bogota-aeropuerto  ❌ incorrecto
```

**Comportamiento esperado:**
```
/armenia/.../hora-recogida/25:00
    ↓ resetea a defaults conscientes de ciudad
/armenia/.../lugar-recogida/armenia-aeropuerto  ✓ correcto
```

## Solución implementada (Opción A)

### 1. Composable context-aware
```typescript
// packages/logic/src/composables/useDefaultRouteParams.ts
export default function useDefaultRouteParams(cityContext?: string) {
    const defaultBranch = cityContext
        ? `${cityContext}-aeropuerto`
        : 'bogota-aeropuerto'; // Fallback global
    // ...
}
```

### 2. Middlewares extraen contexto
```typescript
// En cada middleware (x3)
const pathSegments = to.path.split('/').filter(Boolean);
const cityContext = pathSegments[0]; // "armenia", "medellin", etc.

// Pasar contexto al composable
const { ... } = useDefaultRouteParams(cityContext);
```

## Características

✅ **Backward compatible:** Funciona sin parámetro (fallback a bogota)  
✅ **DRY:** Solución centralizada en composable  
✅ **Tested:** Test e2e que estaba skip ahora pasa  
✅ **Zero breaking changes**

## Casos cubiertos

| Ciudad | Hora inválida | Default aplicado |
|--------|---------------|------------------|
| `/bogota/...` | `25:00` | `bogota-aeropuerto` ✓ |
| `/armenia/...` | `25:00` | `armenia-aeropuerto` ✓ |
| `/medellin/...` | `invalid` | `medellin-aeropuerto` ✓ |
| `/cartagena/...` | `1:00pm` | `cartagena-aeropuerto` ✓ |

## Tests

**Antes del fix:**
- 95 passed + **5 skipped** (bug documentado)
- Test específico con `.skip`

**Después del fix:**
- **100 passed** + 0 skipped ✅
- Test específico activo y pasando

```bash
# Tests e2e
BRAND=alquilatucarro npx playwright test e2e/time-format-12h.spec.ts
# → 100/100 passed ✅

# Tests unitarios
cd packages/logic && pnpm test
# → 16/16 passed ✅
```

## Archivos modificados

| Archivo | Cambios | LOC |
|---------|---------|-----|
| `useDefaultRouteParams.ts` | Acepta cityContext opcional | +9 |
| `validateSearchParams.ts` (alquilatucarro) | Extrae y pasa cityContext | +4 |
| `validateSearchParams.ts` (alquilame) | Extrae y pasa cityContext | +4 |
| `validateSearchParams.ts` (alquicarros) | Extrae y pasa cityContext | +4 |
| `time-format-12h.spec.ts` | Remueve .skip, actualiza comentarios | +3 |
| **Total** | | **~40 LOC** |

## ROI de la solución

**Benefit:** 5 - Solución centralizada, reutilizable, mejor UX  
**Complexity:** 2 - Modificación simple, backward compatible  
**ROI:** +3

## Impacto

**UX:** Mejora experiencia cuando usuarios acceden a enlaces antiguos/inválidos  
**Alcance:** Afecta solo caso de reset a defaults (raro en uso normal)  
**Riesgo:** Bajo - backward compatible, bien testeado

## Relación con otros PRs

- **Depende de:** PR #132 (formato 12h) - este PR extiende esa funcionalidad
- **Base branch:** `main`

## Documentación relacionada

- Bug original documentado en: `docs/known-issues/2026-02-04-defaults-city-context.md`
- Solución Opción A (recomendada) implementada según documento

## Checklist

- [x] Tests pasando (100/100 e2e + 16/16 unitarios)
- [x] Zero breaking changes
- [x] Backward compatible
- [x] Test e2e activado (antes skip)
- [x] Código DRY (solución centralizada)
- [x] Comentarios actualizados