### PR TITLE
fix(header): make hamburger icon visible on mobile

### DIFF
--- a/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
+++ b/packages/ui-alquilatucarro/app/assets/css/rentacar-main/base.css
@@ -101,12 +101,36 @@ header .text-highlighted,
     }
 }
 
-/* UHeader hamburger menu button - force white color */
-header button.lg\:hidden {
+/* Fix: UHeader hamburger/desktop nav — Tailwind v4 scanner doesn't generate */
+/* hidden/block/lg:hidden/lg:block when used dynamically in templates. */
+/* Use structural selectors: first-child = desktop nav, last-child = hamburger */
+
+/* Desktop navigation: hidden on mobile, visible on desktop */
+header [data-slot="right"] > div > div:first-child {
+    display: none;
+}
+@media (min-width: 1024px) {
+    header [data-slot="right"] > div > div:first-child {
+        display: block !important;
+    }
+}
+
+/* Hamburger toggle: visible on mobile, hidden on desktop */
+header [data-slot="right"] > div > div:last-child {
+    display: block;
+}
+@media (min-width: 1024px) {
+    header [data-slot="right"] > div > div:last-child {
+        display: none !important;
+    }
+}
+
+/* Force white color on hamburger button and its Iconify icon */
+header [data-slot="right"] button {
     color: white !important;
 }
-header button.lg\:hidden:hover {
-    color: white !important;
+header [data-slot="right"] button .iconify {
+    background-color: white !important;
 }
 
 /* UHeader slideover panel - white background with dark text */


### PR DESCRIPTION
## Summary

- Fix hamburger menu icon not visible on dark blue header background on mobile
- Replace class-based CSS selectors with structural selectors (`:first-child`, `:last-child`) because Tailwind v4 scanner doesn't generate responsive classes (`hidden`, `block`, `lg:hidden`, `lg:block`) when used dynamically in templates
- Force white color on Iconify CSS-mask icon via `background-color: white`

## Root Cause

Tailwind v4's JIT scanner cannot detect responsive utility classes when they're used in dynamic Vue template contexts. The hamburger wrapper `div class="block lg:hidden"` wasn't generating the expected `.block` and `.lg\:hidden` classes.

## Solution

Use structural CSS selectors instead of class-based selectors:
- `:first-child` → Desktop navigation (hidden on mobile, visible on desktop)
- `:last-child` → Hamburger wrapper (visible on mobile, hidden on desktop)

## Test Plan

- [ ] Verify hamburger icon is visible (white) on mobile viewport
- [ ] Verify hamburger opens slideover menu when clicked
- [ ] Verify desktop navigation is visible on desktop viewport
- [ ] Verify hamburger is hidden on desktop viewport