### PR TITLE
feat(blog): add article #7 "Alquilar Carro en Medellín 2026"

### DIFF
--- a/docs/seo/SESSION-STATE.md
+++ b/docs/seo/SESSION-STATE.md
@@ -6,7 +6,7 @@
 
 **Content Production — Tier 2 In Progress**
 
-Tier 1 Quick Wins completed (5 articles). Tier 2 article #6 (Bogotá guide) submitted as PR #145.
+Tier 1 Quick Wins completed (5 articles). Tier 2 article #6 (Bogotá guide) merged. Now working on Article #7 (Medellín).
 
 ## Completed Work
 
@@ -137,8 +137,8 @@ When adding a new blog article:
 
 | # | Article | Slug | Status | Image |
 |---|---------|------|--------|-------|
-| 6 | Alquilar Carro en Bogotá | `alquilar-carro-bogota-guia` | ⏳ PR #145 | ✅ 1 image (reused) |
-| 7 | Alquilar Carro en Medellín | `alquilar-carro-medellin-guia` | 🔲 Pending | - |
+| 6 | Alquilar Carro en Bogotá | `alquilar-carro-bogota-guia` | ✅ Merged (PR #145) | ✅ 1 image (reused) |
+| 7 | Alquilar Carro en Medellín | `alquilar-carro-medellin-guia` | 🔲 PR Pending | ✅ 1 image (reused) |
 | 8 | Alquilar Carro en Cartagena | `alquilar-carro-cartagena-guia` | 🔲 Pending | - |
 
 ### Article #1 Images (completed)
@@ -170,10 +170,11 @@ API ahora funciona (no más errores 403), pero resultados no son útiles para de
 ## Next Actions
 
 - ✅ ~~Merge PR #144~~ — Completed 2026-02-06
-- ⏳ **Tier 2 Article #6** — PR #145 awaiting merge
+- ✅ ~~Merge PR #145~~ — Completed 2026-02-08 (Article #6 Bogotá)
+- 🔲 **Tier 2 Article #7** — Medellín guide PR pending
+- Continue Tier 2 articles (#8 Cartagena)
 - Monitor Google Search Console for blog indexing (wait 1-2 weeks)
 - Replace Firebase Storage avatar URL with a local file (long-term fix for expired tokens)
-- Continue Tier 2 articles (#7 Medellín, #8 Cartagena)
 
 ## Economic Decisions
 
@@ -182,8 +183,7 @@ API ahora funciona (no más errores 403), pero resultados no son útiles para de
 
 ## Branch State
 
-- **main**: Clean, up to date through PR #144 (Tier 1 complete)
-- **feat/blog-alquilar-carro-bogota**: PR #145 open (Article #6)
+- **main**: Clean, up to date through PR #145 (Tier 2 Article #6 merged)
 - All feature branches deleted after merge
 
 ## Article #5 Images (completed)

--- a/packages/ui-alquilatucarro/content/blog/alquilar-carro-medellin-guia.md
+++ b/packages/ui-alquilatucarro/content/blog/alquilar-carro-medellin-guia.md
@@ -1,0 +1,360 @@
+---
+title: "Alquilar Carro en Medellín 2026: Precios, Requisitos y Tips"
+description: "Guía completa para alquilar carro en Medellín. Zonas de recogida, precios, aeropuerto José María Córdova, rutas a Guatapé y más. ¡Reserva sin anticipos!"
+image: /img/blog/guatape-piedra.webp
+alt: Vista panorámica de la Piedra del Peñol en Guatapé cerca de Medellín
+author:
+  name: Alquilatucarro
+  avatar: https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Flogo.png?alt=media&token=975cfe04-c619-44bc-964a-e6231ca92dfe
+date: 2026-02-09
+category: guias
+tags:
+  - medellin
+  - alquiler
+  - aeropuerto
+  - guatape
+  - precios
+readingTime: 12
+featured: true
+---
+
+Medellín es la puerta de entrada al corazón de Antioquia. Desde la ciudad de la eterna primavera puedes llegar a Guatapé en 2 horas, al Eje Cafetero en 4 horas, o recorrer los pintorescos pueblos del oriente antioqueño en un día. Con un clima perfecto todo el año y carreteras bien mantenidas, alquilar carro en Medellín te abre infinitas posibilidades.
+
+En esta guía te contamos todo sobre el **alquiler de carros en Medellín**: zonas de recogida, precios actualizados, tips de tráfico y las mejores rutas para explorar Antioquia.
+
+## Resumen Rápido: Alquilar Carro en Medellín
+
+| Aspecto | Detalle |
+|---------|---------|
+| **Precio desde** | $115.000/día (compacto) |
+| **Mejor zona para recoger** | Aeropuerto JMC o El Poblado |
+| **Pico y placa** | Lunes a viernes 6:00-8:30 y 16:30-19:30 |
+| **Documentos** | Licencia vigente + cédula/pasaporte + tarjeta crédito |
+| **Anticipación recomendada** | 7-15 días (30+ en Feria de Flores) |
+
+::callout{type="info"}
+**Ventaja del aeropuerto:** El aeropuerto José María Córdova está a 45 min de Medellín, cerca de Guatapé. Si tu destino es el oriente antioqueño, ni siquiera necesitas pasar por la ciudad.
+::
+
+---
+
+## Zonas de Recogida en Medellín
+
+### Aeropuerto José María Córdova (Rionegro)
+
+El aeropuerto internacional está en Rionegro, a 45 minutos del centro de Medellín. Es el punto de partida ideal si planeas explorar el oriente antioqueño.
+
+**Ventajas:**
+- Recogida inmediata al aterrizar
+- Más cerca de Guatapé (1 hora) que desde Medellín (2 horas)
+- Horarios extendidos en la mayoría de empresas
+
+**Desventajas:**
+- 45-60 min hasta El Poblado (puede ser 90+ min en hora pico)
+- Tarifas 15-20% más altas que en ciudad
+
+| Empresa | Ubicación | Horario |
+|---------|-----------|---------|
+| Mostrador principal | Terminal, llegadas | 5:00 AM - 11:00 PM |
+| Counter secundario | Zona de parqueaderos | 6:00 AM - 10:00 PM |
+| Entrega en puerta | Parqueadero cubierto | 24 horas (con reserva) |
+
+::callout{type="success"}
+**Tip:** Si solo vas a Guatapé y pueblos del oriente, recoge el carro en el aeropuerto y evita el tráfico de Medellín completamente.
+::
+
+### El Poblado
+
+La zona más turística de Medellín, con hoteles, restaurantes y vida nocturna. Muchas empresas de alquiler tienen sucursales aquí.
+
+**Ubicaciones populares:**
+- **Parque Lleras** — Centro de la zona rosa
+- **Milla de Oro** — Corredor empresarial
+- **Las Palmas** — Vía hacia el aeropuerto
+
+**Ventajas:**
+- Fácil acceso desde hoteles turísticos
+- Múltiples opciones de empresas
+- Entrega en hotel disponible
+
+### Laureles y Estadio
+
+Zona residencial de clase media alta, con precios más competitivos que El Poblado.
+
+**Ubicaciones:**
+- **Avenida Nutibara** — Principal corredor comercial
+- **La 70** — Zona de restaurantes y comercio
+- **Estadio Atanasio Girardot** — Punto de referencia central
+
+**Ventajas:**
+- Tarifas 10-15% menores que El Poblado
+- Menos tráfico turístico
+- Fácil acceso a autopista hacia el sur
+
+---
+
+## Precios de Alquiler en Medellín 2026
+
+Medellín tiene precios competitivos, ligeramente más altos que Bogotá pero con excelente disponibilidad.
+
+### Tarifas por Tipo de Vehículo
+
+| Tipo | Diario | Semanal | Mensual |
+|------|--------|---------|---------|
+| **Compacto** (Picanto, i10) | $115.000 - $145.000 | $680.000 - $880.000 | $2.100.000 - $2.700.000 |
+| **Sedán** (Onix, Accent) | $140.000 - $180.000 | $850.000 - $1.100.000 | $2.500.000 - $3.400.000 |
+| **SUV** (Tucson, Sportage) | $180.000 - $240.000 | $1.100.000 - $1.450.000 | $3.400.000 - $4.400.000 |
+| **Camioneta 4x4** | $220.000 - $310.000 | $1.300.000 - $1.850.000 | $4.000.000 - $5.400.000 |
+
+### Aeropuerto vs. Ciudad
+
+| Ubicación | Compacto/día | Diferencia |
+|-----------|--------------|------------|
+| Sucursal en ciudad | $115.000 | Base |
+| Aeropuerto JMC | $135.000 | +17% |
+
+Para ver comparativa completa de precios, consulta nuestra [guía de precios de alquiler en Colombia](/blog/precios-alquiler-carros-colombia).
+
+::callout{type="warning"}
+**Feria de Flores (agosto):** Los precios suben 40-60% y la disponibilidad es muy limitada. Reserva con mínimo 45 días de anticipación.
+::
+
+---
+
+## Requisitos para Alquilar en Medellín
+
+Los requisitos son los mismos en toda Colombia:
+
+1. **Licencia de conducir vigente** — Colombiana o internacional
+2. **Documento de identidad** — Cédula (colombianos) o pasaporte (extranjeros)
+3. **Tarjeta de crédito** — Para garantía (algunas empresas aceptan débito)
+4. **Edad mínima** — 21-25 años según la empresa
+
+Consulta todos los detalles en nuestra [guía de requisitos para alquilar carro](/blog/requisitos-alquilar-carro-colombia).
+
+---
+
+## Pico y Placa en Medellín: Lo Que Debes Saber
+
+El pico y placa en Medellín restringe la circulación según el último dígito de la placa. Si alquilas un carro, **la restricción también te aplica**.
+
+### Horarios 2026
+
+| Horario | Días |
+|---------|------|
+| **6:00 AM - 8:30 AM** | Lunes a viernes |
+| **4:30 PM - 7:30 PM** | Lunes a viernes |
+
+### Rotación de Placas
+
+| Día | Placas restringidas |
+|-----|---------------------|
+| Lunes | 0 y 1 |
+| Martes | 2 y 3 |
+| Miércoles | 4 y 5 |
+| Jueves | 6 y 7 |
+| Viernes | 8 y 9 |
+| Sábado y domingo | Sin restricción |
+
+::callout{type="warning"}
+**Multa por violar pico y placa:** Aproximadamente $500.000 COP. Verifica la placa de tu carro de alquiler antes de salir.
+::
+
+### ¿Cómo Evitar Problemas?
+
+1. **Pregunta la placa al reservar** — Planifica según el día que recoges
+2. **Sal temprano o tarde** — Fuera de horarios de restricción
+3. **Usa vías exentas** — Las Palmas, Regional, Autopista Sur
+4. **Viaja los fines de semana** — Sin restricción sábados y domingos
+
+Para información completa y actualizada, revisa nuestra [guía de pico y placa en Colombia](/blog/pico-y-placa-colombia-2026).
+
+---
+
+## Dónde Parquear en Medellín: Costos y Tips
+
+El parqueo en Medellín es más económico que en Bogotá, pero las zonas turísticas tienen demanda alta.
+
+### Tarifas Promedio de Parqueaderos
+
+| Zona | Por hora | Por día |
+|------|----------|---------|
+| Aeropuerto JMC | $5.000 - $7.000 | $40.000 - $55.000 |
+| El Poblado/Lleras | $5.000 - $8.000 | $35.000 - $50.000 |
+| Laureles/La 70 | $3.500 - $5.500 | $25.000 - $40.000 |
+| Centro | $3.000 - $4.500 | $20.000 - $30.000 |
+| Centros comerciales | $3.000 - $5.000 | N/A (máx. 12h) |
+
+### Tips de Parqueo
+
+- **Centros comerciales:** Santa Fe, Oviedo y El Tesoro tienen parqueo amplio
+- **Apps útiles:** Waze y Google Maps muestran parqueaderos con precios
+- **Evita calle en El Poblado:** Zona de alta demanda, usa parqueaderos
+- **Hoteles:** Muchos incluyen parqueadero, confirma antes de reservar
+
+::callout{type="info"}
+**Lleras de noche:** Si vas a la zona rosa, estaciona temprano en un parqueadero vigilado. La zona se llena después de las 8 PM.
+::
+
+---
+
+## Tráfico en Medellín: Tips para Sobrevivir
+
+Medellín tiene tráfico pesado pero más predecible que Bogotá. La topografía del valle crea cuellos de botella específicos.
+
+### Horarios a Evitar
+
+| Franja | Nivel de tráfico |
+|--------|------------------|
+| 6:00 AM - 8:30 AM | 🔴 Crítico |
+| 8:30 AM - 12:00 PM | 🟡 Moderado |
+| 12:00 PM - 4:30 PM | 🟡 Moderado |
+| 4:30 PM - 7:30 PM | 🔴 Crítico |
+| 7:30 PM - 6:00 AM | 🟢 Fluido |
+
+### Vías Principales
+
+- **Las Palmas:** Conecta El Poblado con aeropuerto y oriente. Serpentina con hermosas vistas.
+- **Autopista Sur/Regional:** Eje norte-sur paralelo al río. La más rápida para atravesar la ciudad.
+- **Avenida El Poblado:** Conecta El Poblado con el centro. Tráfico constante.
+- **Autopista Norte:** Salida hacia la costa caribe y Bogotá.
+- **San Juan (Calle 44):** Conecta oriente-occidente. Evitar en hora pico.
+
+### Apps Esenciales
+
+1. **Waze** — Navegación en tiempo real, muy usado en Medellín
+2. **Google Maps** — Alternativa confiable
+3. **Metro de Medellín** — Info del sistema (si dejas el carro un día)
+
+---
+
+## Rutas de Salida desde Medellín
+
+Una vez tengas tu carro, estas son las principales rutas:
+
+### Hacia el Oriente (Guatapé y Pueblos)
+
+**Destinos:** Guatapé, El Peñol, Rionegro, Marinilla, El Retiro
+
+| Ruta | Vía | Tiempo sin tráfico |
+|------|-----|-------------------|
+| Guatapé/El Peñol | Las Palmas → Autopista | 2 horas |
+| Rionegro | Las Palmas → Llanogrande | 45 min |
+| El Retiro | Las Palmas → Desvío | 40 min |
+| Aeropuerto JMC | Las Palmas directo | 45 min |
+
+::callout{type="success"}
+**Tip:** Guatapé los fines de semana se llena. Sal antes de las 7 AM o visita entre semana para disfrutar sin multitudes.
+::
+
+### Hacia el Sur (Eje Cafetero)
+
+**Destinos:** Manizales, Pereira, Armenia, Salento
+
+| Ruta | Vía | Tiempo sin tráfico |
+|------|-----|-------------------|
+| Manizales | Autopista Sur → La Pintada | 4 horas |
+| Pereira | Autopista Sur → La Virginia | 4.5 horas |
+| Salento | Autopista Sur → Armenia | 5.5 horas |
+
+### Hacia el Norte (Costa Caribe)
+
+**Destinos:** Cartagena, Santa Marta, Barranquilla
+
+| Ruta | Vía | Tiempo sin tráfico |
+|------|-----|-------------------|
+| Cartagena | Autopista Norte → Sincelejo | 10-11 horas |
+| Santa Marta | Autopista Norte → Valledupar | 12 horas |
+
+### Hacia Bogotá
+
+| Ruta | Vía | Tiempo sin tráfico |
+|------|-----|-------------------|
+| Bogotá | Autopista → Puerto Triunfo → Honda | 8-9 horas |
+
+Para itinerarios de turismo en la zona, revisa nuestra guía del [Eje Cafetero en carro](/blog/eje-cafetero-en-carro-guia-completa).
+
+---
+
+## ¿Qué Tipo de Carro Elegir en Medellín?
+
+Depende de tu plan de viaje:
+
+| Plan | Carro recomendado | Por qué |
+|------|-------------------|---------|
+| Solo Medellín | Compacto | Fácil parquear, económico |
+| Medellín + Guatapé | Sedán o SUV | Comodidad en Las Palmas |
+| Pueblos del oriente | SUV | Algunas vías son empinadas |
+| Eje Cafetero | SUV | Carreteras de montaña |
+| Costa Caribe | Sedán o SUV | Viaje largo, comodidad |
+
+::callout{type="info"}
+**Nota sobre Las Palmas:** Esta vía tiene muchas curvas y pendientes. Un sedán funciona bien, pero un SUV ofrece mejor visibilidad y potencia en subidas.
+::
+
+Consulta nuestra [guía de tipos de carros](/blog/tipos-carros-alquilar-cual-elegir) para elegir el ideal.
+
+---
+
+## Atracciones Cercanas a Medellín
+
+Con carro propio puedes explorar joyas que el transporte público no alcanza:
+
+### Imperdibles en 1 Día
+
+| Destino | Distancia | Tiempo | Qué ver |
+|---------|-----------|--------|---------|
+| Guatapé | 80 km | 2 h | Piedra del Peñol, pueblo de colores |
+| El Retiro | 35 km | 40 min | Artesanías, naturaleza |
+| Santa Elena | 15 km | 30 min | Silleteros, fincas, naturaleza |
+| Jardín | 135 km | 3.5 h | Pueblo patrimonio, café |
+
+### Escapadas de Fin de Semana
+
+| Destino | Distancia | Tiempo | Qué ver |
+|---------|-----------|--------|---------|
+| Eje Cafetero | 200 km | 4-5 h | Salento, Valle del Cocora |
+| Jericó | 110 km | 3 h | Pueblo del Beato, teleférico |
+| Santa Fe de Antioquia | 80 km | 1.5 h | Colonial, Puente de Occidente |
+
+---
+
+## Preguntas Frecuentes
+
+### ¿Dónde es mejor recoger el carro en Medellín?
+
+Si llegas en avión y vas al oriente antioqueño (Guatapé), recoge en el **Aeropuerto JMC** — ya estás a medio camino. Si te quedas en la ciudad, las sucursales en **El Poblado o Laureles** ofrecen mejores precios y menor recargo.
+
+### ¿Me afecta el pico y placa si alquilo un carro?
+
+Sí. La restricción aplica por placa, sin importar si el vehículo es propio o alquilado. Verifica el último dígito de la placa y planifica tu itinerario según los días de restricción.
+
+### ¿Puedo devolver el carro en otra ciudad?
+
+Sí, la mayoría de empresas permiten devolución en otra ciudad (one-way) con un cargo adicional de $150.000 a $400.000 dependiendo de la distancia.
+
+### ¿Necesito carro dentro de Medellín?
+
+Para turismo dentro de la ciudad, el Metro y apps de transporte son muy eficientes. El carro es ideal si planeas explorar Guatapé, pueblos del oriente o hacer road trips largos.
+
+### ¿Es seguro manejar en Medellín?
+
+Sí, Medellín es segura para conducir. Las vías están bien señalizadas y la ciudad tiene buena infraestructura. Las Palmas es serpenteante pero tiene excelente pavimento. Usa Waze y evita dejar objetos visibles en el carro.
+
+### ¿Cuánto cuesta el peaje al aeropuerto?
+
+El peaje en la vía Las Palmas cuesta aproximadamente $16.500 COP (2026) por sentido. Es autopista de excelente calidad.
+
+---
+
+## Conclusión: ¿Vale la Pena Alquilar Carro en Medellín?
+
+Alquilar carro en Medellín es la mejor decisión si quieres explorar el oriente antioqueño, visitar pueblos como Guatapé y Jardín, o hacer road trips hacia el Eje Cafetero o la costa. Con precios desde **$115.000/día** y clima perfecto todo el año, tener tu propio vehículo te da libertad total.
+
+**Recuerda:**
+- Reserva con anticipación (especialmente en Feria de Flores)
+- Verifica la placa para el pico y placa
+- Usa Las Palmas para el oriente (vistas espectaculares)
+- Waze es tu mejor aliado
+
+**¿Listo para explorar Antioquia?** [Busca tu carro ideal](/medellin) y compara precios de múltiples proveedores. Sin anticipos, sin letra pequeña.

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -609,6 +609,7 @@ export default defineNuxtConfig({
         '/blog/turismo-santander-en-carro',
         '/blog/turismo-boyaca-en-carro',
         '/blog/alquilar-carro-bogota-guia',
+        '/blog/alquilar-carro-medellin-guia',
       ]
     }
   },
@@ -655,6 +656,7 @@ export default defineNuxtConfig({
       { loc: '/blog/turismo-santander-en-carro', changefreq: 'monthly', priority: 0.7 },
       { loc: '/blog/turismo-boyaca-en-carro', changefreq: 'monthly', priority: 0.7 },
       { loc: '/blog/alquilar-carro-bogota-guia', changefreq: 'monthly', priority: 0.7 },
+      { loc: '/blog/alquilar-carro-medellin-guia', changefreq: 'monthly', priority: 0.7 },
     ],
     exclude: ['/pendiente', '/sindisponibilidad', '/reservado/**', '/*/buscar-vehiculos/**', '/seo/**'],
   },

--- a/packages/ui-alquilatucarro/public/rss.xml
+++ b/packages/ui-alquilatucarro/public/rss.xml
@@ -5,8 +5,16 @@
     <link>https://alquilatucarro.com/blog</link>
     <description>Guías, tips y consejos para alquilar carros en Colombia. Rutas, requisitos y recomendaciones para tu viaje.</description>
     <language>es-co</language>
-    <lastBuildDate>Sun, 08 Feb 2026 00:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Mon, 09 Feb 2026 00:00:00 GMT</lastBuildDate>
     <atom:link href="https://alquilatucarro.com/rss.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Alquilar Carro en Medellín 2026: Precios, Requisitos y Tips</title>
+      <link>https://alquilatucarro.com/blog/alquilar-carro-medellin-guia</link>
+      <guid isPermaLink="true">https://alquilatucarro.com/blog/alquilar-carro-medellin-guia</guid>
+      <description>Guía completa para alquilar carro en Medellín. Zonas de recogida, precios, aeropuerto José María Córdova, rutas a Guatapé y más. ¡Reserva sin anticipos!</description>
+      <pubDate>Mon, 09 Feb 2026 00:00:00 GMT</pubDate>
+      <category>guias</category>
+    </item>
     <item>
       <title>Alquilar Carro en Bogotá 2026: Precios, Requisitos y Tips</title>
       <link>https://alquilatucarro.com/blog/alquilar-carro-bogota-guia</link>


### PR DESCRIPTION
## Summary

- New Tier 2 city guide for car rental in Medellín
- Covers: pickup zones (JMC airport, El Poblado, Laureles), prices, requirements, parking
- Routes to popular destinations: Guatapé, Santa Fe de Antioquia, Jardín
- Traffic tips and metro integration advice

## Changes

- `content/blog/alquilar-carro-medellin-guia.md` — New article (~350 lines)
- `public/rss.xml` — Added new entry, updated lastBuildDate
- `nuxt.config.ts` — Added URL to sitemap.urls and prerender.routes
- `docs/seo/SESSION-STATE.md` — Updated progress tracking

## Image

Reuses existing hero image: `/img/blog/guatape-piedra.webp`

## Test plan

- [ ] CI/CD passes
- [ ] Article renders correctly at `/blog/alquilar-carro-medellin-guia`
- [ ] RSS feed includes new entry
- [ ] Sitemap includes new URL