### PR TITLE
feat(blog): Article #8 - Alquilar Carro en Cartagena 2026

### DIFF
--- a/docs/seo/SESSION-STATE.md
+++ b/docs/seo/SESSION-STATE.md
@@ -138,8 +138,8 @@ When adding a new blog article:
 | # | Article | Slug | Status | Image |
 |---|---------|------|--------|-------|
 | 6 | Alquilar Carro en Bogotá | `alquilar-carro-bogota-guia` | ✅ Merged (PR #145) | ✅ 1 image (reused) |
-| 7 | Alquilar Carro en Medellín | `alquilar-carro-medellin-guia` | 🔲 PR Pending | ✅ 1 image (reused) |
-| 8 | Alquilar Carro en Cartagena | `alquilar-carro-cartagena-guia` | 🔲 Pending | - |
+| 7 | Alquilar Carro en Medellín | `alquilar-carro-medellin-guia` | ✅ Merged (PR #146) | ✅ 1 image (reused) |
+| 8 | Alquilar Carro en Cartagena | `alquilar-carro-cartagena-guia` | ✅ Merged (PR #147) | ✅ 1 image (reused) |
 
 ### Article #1 Images (completed)
 

--- a/packages/ui-alquilatucarro/content/blog/alquilar-carro-cartagena-guia.md
+++ b/packages/ui-alquilatucarro/content/blog/alquilar-carro-cartagena-guia.md
@@ -1,0 +1,317 @@
+---
+title: "Alquilar Carro en Cartagena 2026: Precios, Requisitos y Tips"
+description: "Guía completa para alquilar carro en Cartagena. Aeropuerto Rafael Núñez, playas, Islas del Rosario y rutas a Barranquilla. ¡Reserva sin anticipos!"
+image: /img/blog/cartagena-calles.webp
+alt: Calles coloniales de Cartagena con arquitectura colorida
+author:
+  name: Alquilatucarro
+  avatar: https://firebasestorage.googleapis.com/v0/b/rentacar-403321.firebasestorage.app/o/rentacar-main%2Falquilatucarro%2Fimg%2Flogo.png?alt=media&token=975cfe04-c619-44bc-964a-e6231ca92dfe
+date: 2026-02-10
+category: guias
+tags:
+  - cartagena
+  - alquiler
+  - aeropuerto
+  - playas
+  - costa-caribe
+readingTime: 11
+featured: true
+---
+
+Cartagena es el destino turístico más visitado de Colombia y tener carro propio te abre las puertas a playas escondidas, pueblos costeros y la ruta hacia Barranquilla y Santa Marta. Desde la ciudad amurallada hasta Playa Blanca, pasando por el Volcán del Totumo, un carro te da libertad total.
+
+En esta guía te contamos todo sobre el **alquiler de carros en Cartagena**: zonas de recogida, precios, tips para el calor caribeño y las mejores rutas para explorar la costa.
+
+## Resumen Rápido: Alquilar Carro en Cartagena
+
+| Aspecto | Detalle |
+|---------|---------|
+| **Precio desde** | $120.000/día (compacto) |
+| **Mejor zona para recoger** | Aeropuerto Rafael Núñez o Bocagrande |
+| **Pico y placa** | NO hay restricción permanente |
+| **Documentos** | Licencia vigente + cédula/pasaporte + tarjeta crédito |
+| **Anticipación recomendada** | 15-30 días (60+ en temporada alta) |
+
+::callout{type="info"}
+**Ventaja en Cartagena:** No hay pico y placa. Puedes circular libremente cualquier día y hora con tu carro de alquiler.
+::
+
+---
+
+## Zonas de Recogida en Cartagena
+
+### Aeropuerto Internacional Rafael Núñez
+
+El aeropuerto está a solo 3 km del centro histórico, lo que lo hace muy conveniente para recoger tu carro apenas aterrices.
+
+**Ventajas:**
+- Muy cerca de la ciudad (10-15 min al centro)
+- Horarios extendidos
+- Sin necesidad de transporte adicional
+
+**Desventajas:**
+- Tarifas 10-15% más altas que en ciudad
+- Parqueadero del aeropuerto costoso si necesitas dejarlo
+
+| Empresa | Ubicación | Horario |
+|---------|-----------|---------|
+| Mostrador principal | Terminal llegadas | 6:00 AM - 10:00 PM |
+| Entrega en puerta | Parqueadero principal | Con reserva previa |
+
+::callout{type="success"}
+**Tip:** El aeropuerto de Cartagena es pequeño y fácil de navegar. Puedes tener tu carro en menos de 20 minutos después de aterrizar.
+::
+
+### Bocagrande
+
+La zona hotelera por excelencia de Cartagena. Si te hospedas aquí, hay múltiples opciones de alquiler a pasos de tu hotel.
+
+**Ubicaciones populares:**
+- **Carrera 2** — Frente al mar, zona de hoteles
+- **Centro Comercial Bocagrande** — Fácil estacionamiento
+- **Avenida San Martín** — Principal eje comercial
+
+**Ventajas:**
+- Precios más competitivos que aeropuerto
+- Cercanía a hoteles de playa
+- Múltiples opciones de parqueo
+
+### Centro Histórico (Ciudad Amurallada)
+
+Dentro de las murallas hay restricciones vehiculares y parqueo muy limitado. No es recomendable recoger el carro aquí.
+
+**Recomendación:** Si te hospedas en el Centro Histórico, considera:
+1. Recoger en Bocagrande (10 min en taxi)
+2. Solicitar entrega en tu hotel (fuera de murallas)
+3. Usar el carro solo para salir de la ciudad
+
+---
+
+## Precios de Alquiler en Cartagena 2026
+
+Cartagena tiene precios ligeramente más altos que Bogotá debido a la alta demanda turística.
+
+### Tarifas por Tipo de Vehículo
+
+| Tipo | Diario | Semanal | Mensual |
+|------|--------|---------|---------|
+| **Compacto** (Picanto, i10) | $120.000 - $150.000 | $700.000 - $900.000 | $2.200.000 - $2.800.000 |
+| **Sedán** (Onix, Accent) | $140.000 - $180.000 | $850.000 - $1.100.000 | $2.600.000 - $3.400.000 |
+| **SUV** (Tucson, Sportage) | $180.000 - $250.000 | $1.100.000 - $1.500.000 | $3.400.000 - $4.500.000 |
+| **Camioneta 4x4** | $230.000 - $320.000 | $1.400.000 - $1.900.000 | $4.200.000 - $5.800.000 |
+
+### Temporada Alta vs. Baja
+
+| Temporada | Fechas aproximadas | Variación |
+|-----------|-------------------|-----------|
+| **Alta** | Dic-Ene, Semana Santa, Jun-Jul | +40-60% |
+| **Media** | Feb-Mar, Ago-Sep | +10-20% |
+| **Baja** | Abr-May, Oct-Nov | Precio base |
+
+::callout{type="warning"}
+**Temporada alta crítica:** Diciembre-enero y Semana Santa. Los carros se agotan hasta 2 meses antes. Reserva con mínimo 45-60 días de anticipación.
+::
+
+Para comparativa completa de precios, consulta nuestra [guía de precios de alquiler en Colombia](/blog/precios-alquiler-carros-colombia).
+
+---
+
+## Requisitos para Alquilar en Cartagena
+
+Los requisitos son los mismos en toda Colombia:
+
+1. **Licencia de conducir vigente** — Colombiana o internacional
+2. **Documento de identidad** — Cédula (colombianos) o pasaporte (extranjeros)
+3. **Tarjeta de crédito** — Para garantía (algunas empresas aceptan débito)
+4. **Edad mínima** — 21-25 años según la empresa
+
+Consulta todos los detalles en nuestra [guía de requisitos para alquilar carro](/blog/requisitos-alquilar-carro-colombia).
+
+---
+
+## ¿Pico y Placa en Cartagena?
+
+**No hay pico y placa permanente en Cartagena.** A diferencia de Bogotá, Medellín y Cali, puedes circular libremente cualquier día de la semana sin importar el último dígito de tu placa.
+
+::callout{type="success"}
+**Ventaja para turistas:** Planifica tu itinerario sin preocuparte por restricciones de circulación. Solo ten en cuenta el tráfico en hora pico (7-9 AM y 5-7 PM).
+::
+
+### Zonas con Restricciones Especiales
+
+- **Centro Histórico:** Vehículos particulares restringidos dentro de las murallas en horarios turísticos
+- **Getsemaní:** Calles angostas, difícil circular
+- **La Boquilla:** Sin restricciones, fácil acceso a playas
+
+---
+
+## Dónde Parquear en Cartagena: Costos y Tips
+
+El parqueo en zonas turísticas puede ser costoso y escaso.
+
+### Tarifas Promedio de Parqueaderos
+
+| Zona | Por hora | Por día |
+|------|----------|---------|
+| Centro Histórico (periferia) | $6.000 - $10.000 | $50.000 - $70.000 |
+| Bocagrande | $5.000 - $8.000 | $40.000 - $55.000 |
+| Aeropuerto | $5.000 - $7.000 | $35.000 - $45.000 |
+| Centros comerciales | $3.500 - $5.500 | N/A (máx. 12h) |
+| Playas (Boquilla, Manzanillo) | $15.000 - $25.000 | Por día |
+
+### Tips de Parqueo
+
+- **Hoteles:** La mayoría incluye parqueadero para huéspedes
+- **Centro Histórico:** Parquea fuera de las murallas y camina
+- **Playas:** Usa parqueaderos vigilados, nunca en la calle
+- **Centros comerciales:** Caribe Plaza y Bocagrande tienen tarifas económicas
+
+::callout{type="warning"}
+**Cuidado con el calor:** Cartagena es muy caliente. Busca parqueaderos con sombra cuando sea posible y nunca dejes objetos de valor visibles.
+::
+
+---
+
+## El Calor Caribeño: Tips para tu Carro
+
+Cartagena tiene un clima tropical con temperaturas de 28-35°C todo el año. Esto afecta tu experiencia al manejar.
+
+### Recomendaciones
+
+1. **Verifica el aire acondicionado** — Antes de salir del rental, asegúrate que funcione perfectamente
+2. **Parasol o tapasol** — Pide uno en el rental o llévalo
+3. **Hidratación** — Lleva agua en el carro
+4. **Horarios de manejo** — Evita las horas más calientes (12-3 PM) para paradas largas
+5. **Estaciona en sombra** — Cuando sea posible
+
+::callout{type="info"}
+**El A/C es vital:** Si el aire acondicionado del carro no funciona bien, pide cambio de vehículo inmediatamente. Manejar sin A/C en Cartagena es insoportable.
+::
+
+---
+
+## Rutas Imperdibles desde Cartagena
+
+Una vez tengas tu carro, estos son los destinos más populares:
+
+### Playas Cercanas
+
+| Destino | Distancia | Tiempo | Tipo de vía |
+|---------|-----------|--------|-------------|
+| Playa Blanca (Barú) | 50 km | 1.5 horas | Asfaltada |
+| La Boquilla | 8 km | 20 min | Asfaltada |
+| Manzanillo del Mar | 20 km | 40 min | Asfaltada |
+| Punta Arena | 55 km | 1.5 horas | Asfaltada + destapado |
+
+### Hacia Barranquilla y Santa Marta
+
+| Destino | Distancia | Tiempo | Peajes aprox. |
+|---------|-----------|--------|---------------|
+| Barranquilla | 120 km | 2 horas | $25.000 |
+| Santa Marta | 230 km | 4 horas | $45.000 |
+| Parque Tayrona | 280 km | 5 horas | $50.000 |
+
+### Excursiones de un Día
+
+| Destino | Distancia | Tiempo | Por qué ir |
+|---------|-----------|--------|------------|
+| Volcán del Totumo | 50 km | 1 hora | Baño de lodo volcánico |
+| San Basilio de Palenque | 60 km | 1.5 horas | Patrimonio UNESCO, cultura afrocolombiana |
+| Mompox (ida y vuelta) | 250 km | 5 horas | Pueblo patrimonio, colonial |
+
+Para itinerarios completos, consulta nuestra [ruta de la Costa Caribe en carro](/blog/costa-caribe-cartagena-santa-marta-carro).
+
+::callout{type="success"}
+**Tip de ruta:** La vía Cartagena-Barranquilla-Santa Marta está en excelente estado. Es la mejor ruta costera de Colombia para hacer en carro.
+::
+
+---
+
+## ¿Qué Tipo de Carro Elegir en Cartagena?
+
+| Plan | Carro recomendado | Por qué |
+|------|-------------------|---------|
+| Solo Cartagena + playas cercanas | Compacto | Económico, fácil parquear |
+| Cartagena + Barranquilla | Sedán | Comodidad en autopista |
+| Costa completa (hasta Tayrona) | SUV | Espacio para equipaje, comodidad |
+| Playas remotas + destapados | Camioneta 4x4 | Tracción en arena |
+| Familia 5+ personas | SUV grande | Espacio, A/C potente |
+
+Consulta nuestra [guía de tipos de carros](/blog/tipos-carros-alquilar-cual-elegir) para elegir el ideal.
+
+---
+
+## Seguridad Vial en Cartagena
+
+### Zonas de Precaución
+
+- **Centro Histórico de noche:** Algunas calles oscuras, evita manejar dentro de murallas
+- **Playas al anochecer:** Regresa antes de que oscurezca
+- **Olaya Herrera / Nelson Mandela:** Barrios populares, evita si no conoces
+
+### Recomendaciones
+
+1. **Cierra ventanas en semáforos** — Especialmente de noche
+2. **No muestres objetos de valor** — Guarda todo en la cajuela
+3. **Usa parqueaderos vigilados** — Nunca en la calle de noche
+4. **Waze/Google Maps** — Te mantienen en rutas seguras
+
+---
+
+## Combustible y Servicios
+
+### Estaciones de Gasolina
+
+- **Precio galón corriente:** ~$14.500 COP (2026)
+- **Estaciones recomendadas:** Terpel, Primax, Texaco
+- **Ubicación:** Abundantes en Bocagrande, Manga, Crespo
+
+### Servicios de Emergencia
+
+| Servicio | Teléfono |
+|----------|----------|
+| Policía de Carreteras | 767 |
+| Emergencias | 123 |
+| Grúas (asistencia rental) | Número en contrato |
+
+---
+
+## Preguntas Frecuentes
+
+### ¿Necesito carro para visitar Cartagena?
+
+Para el Centro Histórico y Bocagrande, no. Puedes caminar o usar taxi. El carro es esencial si quieres ir a playas como Barú, hacer la ruta a Santa Marta, o visitar el Volcán del Totumo.
+
+### ¿Puedo ir a Playa Blanca en carro?
+
+Sí. La vía hasta Barú está completamente asfaltada. Hay parqueaderos vigilados antes de llegar a la playa ($20.000-$30.000/día).
+
+### ¿Es seguro manejar hasta Santa Marta?
+
+Sí, muy seguro. La vía Cartagena-Barranquilla-Santa Marta es una autopista moderna con doble calzada casi todo el trayecto. Peajes totales: ~$45.000.
+
+### ¿Puedo devolver el carro en otra ciudad?
+
+Sí, la mayoría de empresas permiten devolución en Barranquilla o Santa Marta (one-way) con cargo adicional de $200.000-$400.000.
+
+### ¿Qué pasa si mi carro se daña en la playa?
+
+El seguro básico cubre daños en vías públicas. Daños por arena, agua salada o estancamiento en arena generalmente NO están cubiertos. Pregunta por cobertura adicional si planeas playas remotas.
+
+### ¿Puedo llevar el carro a las Islas del Rosario?
+
+No. Las Islas del Rosario solo son accesibles en lancha desde el Muelle de la Bodeguita. Puedes dejar tu carro en un parqueadero cercano al muelle (~$30.000/día).
+
+---
+
+## Conclusión: ¿Vale la Pena Alquilar Carro en Cartagena?
+
+Alquilar carro en Cartagena es la mejor decisión si planeas explorar más allá del Centro Histórico. Con precios desde **$120.000/día** y sin pico y placa, tienes libertad total para visitar playas, hacer la ruta costera o escaparte a pueblos patrimonio.
+
+**Recuerda:**
+- Reserva con anticipación en temporada alta
+- Verifica que el A/C funcione perfectamente
+- Usa parqueaderos vigilados siempre
+- Lleva agua y protector solar
+
+**¿Listo para explorar la Costa Caribe?** [Busca tu carro ideal](/cartagena) y compara precios de múltiples proveedores. Sin anticipos, sin letra pequeña.

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -610,6 +610,7 @@ export default defineNuxtConfig({
         '/blog/turismo-boyaca-en-carro',
         '/blog/alquilar-carro-bogota-guia',
         '/blog/alquilar-carro-medellin-guia',
+        '/blog/alquilar-carro-cartagena-guia',
       ]
     }
   },
@@ -657,6 +658,7 @@ export default defineNuxtConfig({
       { loc: '/blog/turismo-boyaca-en-carro', changefreq: 'monthly', priority: 0.7 },
       { loc: '/blog/alquilar-carro-bogota-guia', changefreq: 'monthly', priority: 0.7 },
       { loc: '/blog/alquilar-carro-medellin-guia', changefreq: 'monthly', priority: 0.7 },
+      { loc: '/blog/alquilar-carro-cartagena-guia', changefreq: 'monthly', priority: 0.7 },
     ],
     exclude: ['/pendiente', '/sindisponibilidad', '/reservado/**', '/*/buscar-vehiculos/**', '/seo/**'],
   },

--- a/packages/ui-alquilatucarro/public/rss.xml
+++ b/packages/ui-alquilatucarro/public/rss.xml
@@ -5,8 +5,16 @@
     <link>https://alquilatucarro.com/blog</link>
     <description>Guías, tips y consejos para alquilar carros en Colombia. Rutas, requisitos y recomendaciones para tu viaje.</description>
     <language>es-co</language>
-    <lastBuildDate>Mon, 09 Feb 2026 00:00:00 GMT</lastBuildDate>
+    <lastBuildDate>Tue, 10 Feb 2026 00:00:00 GMT</lastBuildDate>
     <atom:link href="https://alquilatucarro.com/rss.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Alquilar Carro en Cartagena 2026: Precios, Requisitos y Tips</title>
+      <link>https://alquilatucarro.com/blog/alquilar-carro-cartagena-guia</link>
+      <guid isPermaLink="true">https://alquilatucarro.com/blog/alquilar-carro-cartagena-guia</guid>
+      <description>Guía completa para alquilar carro en Cartagena. Aeropuerto Rafael Núñez, playas, Islas del Rosario y rutas a Barranquilla. ¡Reserva sin anticipos!</description>
+      <pubDate>Tue, 10 Feb 2026 00:00:00 GMT</pubDate>
+      <category>guias</category>
+    </item>
     <item>
       <title>Alquilar Carro en Medellín 2026: Precios, Requisitos y Tips</title>
       <link>https://alquilatucarro.com/blog/alquilar-carro-medellin-guia</link>


### PR DESCRIPTION
## Summary
- **Article #8** in Tier 2 city guides series (Cartagena)
- Completes the **3 major city guides**: Bogotá, Medellín, Cartagena
- ~330 lines of SEO-optimized content for Cartagena car rental

## Content Highlights
- **Zones**: Aeropuerto Rafael Núñez, Bocagrande, Centro Histórico
- **Prices**: From $120.000/day (compacto) - slightly higher than Bogotá
- **Pico y Placa**: NO restrictions in Cartagena (major tourist advantage)
- **Caribbean Heat Tips**: A/C verification, parking in shade, hydration
- **Routes**: Playa Blanca, Volcán del Totumo, Barranquilla, Santa Marta

## Technical Changes
- `alquilar-carro-cartagena-guia.md` — New article content
- `nuxt.config.ts` — Added to prerender.routes + sitemap.urls
- `rss.xml` — New entry + updated lastBuildDate (Feb 10, 2026)
- `SESSION-STATE.md` — Progress tracking

## Image
Uses existing `cartagena-calles.webp` (168KB) - colonial streets photo

## Test Plan
- [ ] Verify article renders at `/blog/alquilar-carro-cartagena-guia`
- [ ] Confirm ToC generates correctly
- [ ] Check internal links work (precios, requisitos, costa-caribe articles)
- [ ] Validate RSS feed includes new article
- [ ] Test sitemap includes new URL