### PR TITLE
fix(ci): force glibc on Firebase Functions npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,7 @@ jobs:
         working-directory: packages/${{ matrix.config.package }}/.output/server
         run: |
           rm -rf node_modules package-lock.json
-          echo "libc=glibc" >> .npmrc
+          echo "libc=glibc" > .npmrc
           npm install --omit=dev
 
       - name: Deploy to Firebase Hosting


### PR DESCRIPTION
## Summary

fix changes affecting **1** file (Δ1 LOC).

Hotfix for production deploy failure introduced by PR #152 (WordPress Blog API). The `sharp` image library added in that PR uses platform-specific native binaries. The pnpm lockfile resolved `@img/sharp-libvips-linuxmusl-x64` (Alpine/musl), but GitHub Actions runners and Firebase Functions both use glibc (Debian/Ubuntu), causing `EBADPLATFORM` on the "Fix Firebase Functions dependencies" step.

## Changes (2 commits)

- b7480fc fix(ci): use overwrite instead of append for .npmrc in deploy step
- c1d41c1 fix(ci): force glibc on Firebase Functions npm install

## Pre-PR Quality Gate

### Code Review: Clean ✅

**Strengths:**
- Root cause correctly identified (musl lockfile pinning wrong binary)
- `libc=glibc` is the correct npm mechanism for platform binary selection
- Fix applies uniformly to all 3 brand matrix entries
- Minimal scope: 1 file, 3 lines

**Issues Addressed:**
- [Important] Changed `>>` to `>` for `.npmrc` write — overwrite makes intent explicit and prevents duplication if build ever emits a pre-existing `.npmrc`

### Security Review: 0 High, 0 Medium ✅

✅ No security vulnerabilities detected. The `.npmrc` write uses a static hardcoded string (`libc=glibc`) with no user-controlled input. Supply chain risk profile is unchanged from before this PR (Nitro does not generate `package-lock.json` in `.output/server`).

### Observations

| Check | Status |
|-------|--------|
| Tests | ✅ CI-only change — no source files modified |
| API Changes | ✅ None |
| Breaking Changes | ✅ None |
| Complexity | ✅ S: Δ1 LOC |

## Test Plan

- [ ] Deploy pipeline completes without EBADPLATFORM error
- [ ] Firebase Functions deploy succeeds for all 3 brands (alquilatucarro, alquicarros, alquilame)
- [ ] Sharp image processing works correctly in Firebase Functions runtime post-deploy
