### PR TITLE
fix(ci): add workflow_dispatch and fix deploy detection for deploy.yml changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,14 @@ jobs:
         run: |
           BRANCH="${{ github.ref_name }}"
 
+          # Guard: workflow_dispatch is only permitted on protected branches
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "alquicarros" ]; then
+              echo "workflow_dispatch is only permitted on main or alquicarros branches"
+              exit 1
+            fi
+          fi
+
           # Get changed files
           if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ] || [ -z "${{ github.event.before }}" ]; then
             # First push to branch or before is empty, compare with HEAD~1
@@ -46,14 +54,6 @@ jobs:
           echo "$CHANGED_FILES"
 
           DEPLOY_BRANDS=()
-
-          # Guard: workflow_dispatch is only permitted on protected branches
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "$BRANCH" != "main" ] && [ "$BRANCH" != "alquicarros" ]; then
-              echo "workflow_dispatch is only permitted on main or alquicarros branches"
-              exit 1
-            fi
-          fi
 
           # Manual trigger: force deploy all brands
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.force_all_brands }}" = "true" ]; then
@@ -138,6 +138,12 @@ jobs:
             esac
           done
 
+          if [ "$BRANDS_JSON" = "[]" ]; then
+            echo "No brands detected for deployment."
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "Manual trigger detected: use force_all_brands=true to force a full redeploy."
+            fi
+          fi
           echo "Brands to deploy: $BRANDS_JSON"
           echo "brands=$BRANDS_JSON" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

fix changes affecting **1** file (Δ41 LOC).

Fixes two gaps in the deploy pipeline that caused blog API routes (PR #152) to never reach production:

1. **Blog API never deployed**: PR #152 (7K LOC) deploy FAILED (EBADPLATFORM). PR #153 (glibc fix) deploy SKIPPED — only `deploy.yml` changed, detection logic didn't cover that case. Result: blog API routes don't exist in production.
2. **No manual trigger capability**: no way to force a redeploy without touching a brand file.

**Self-bootstrapping**: merging this PR detects `deploy.yml` changed → deploys all 3 brands → blog API routes finally reach Firebase Functions.

## Changes (3 commits)

- 52bf184 fix(ci): improve workflow_dispatch guard ordering and no-op diagnostics
- b07c0ee fix(ci): address pre-PR security and correctness findings
- beb780e fix(ci): add workflow_dispatch and fix deploy detection for deploy.yml changes

## Pre-PR Quality Gate (3 passes)

### Code Review: Clean ✅ (after 3-pass auto-fix loop)

**Strengths:**
- Root cause diagnosis accurate and well-documented
- Self-bootstrapping: merge triggers the needed redeploy automatically
- Additive detection logic with dedup is cleaner and more extensible than original if/else
- Branch scoping (`alquilatucarro` main-only) preserved consistently across all blocks

**Issues Addressed:**
- [Important] grep pattern missing end anchor `$` → added to prevent false positives from `deploy.yml.bak`
- [Important] Branch guard executed after git diff → moved before CHANGED_FILES block
- [Important] workflow_dispatch with `force_all_brands=false` produced silent no-op → added diagnostic log with hint
- [Medium Security] workflow_dispatch had no branch restriction → runtime guard exits before any deployment if branch ≠ main/alquicarros
- [Low Security] `github.event.before` unquoted in git diff → quoted

### Security Review: 0 High, 0 Medium ✅

✅ No security vulnerabilities detected. Branch guard confirmed effective (runs before any deployment logic). `force_all_brands` input scoped to string comparison only, no injection surface.

### Observations

| Check | Status |
|-------|--------|
| Tests | ✅ CI-only change |
| API Changes | ✅ None |
| Breaking Changes | ✅ None |
| Complexity | ✅ M: Δ41 LOC |

## Test Plan

- [ ] Merge → verify deploy workflow triggers for all 3 brands (self-bootstrapping)
- [ ] Blog API routes accessible in production after deploy completes
- [ ] `workflow_dispatch` with `force_all_brands=true` from main → deploys all 3 brands
- [ ] `workflow_dispatch` with `force_all_brands=false` → shows diagnostic hint in logs
- [ ] `workflow_dispatch` from non-protected branch → exits with error message
