### PR TITLE
fix(ci): patch musl sharp packages from Nitro output before npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,7 +216,16 @@ jobs:
         working-directory: packages/${{ matrix.config.package }}/.output/server
         run: |
           rm -rf node_modules package-lock.json
-          echo "libc=glibc" > .npmrc
+          # Remove musl-only sharp packages to prevent EBADPLATFORM on glibc runners.
+          # libc=glibc is a pnpm setting; npm ignores it, so we patch package.json directly.
+          node -e "
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const musl = ['@img/sharp-libvips-linuxmusl-x64','@img/sharp-libvips-linuxmusl-arm64','@img/sharp-linuxmusl-x64','@img/sharp-linuxmusl-arm64'];
+          musl.forEach(p => { delete (pkg.dependencies||{})[p]; delete (pkg.optionalDependencies||{})[p]; });
+          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+          console.log('Removed musl packages:', musl.join(', '));
+          "
           npm install --omit=dev
 
       - name: Deploy to Firebase Hosting


### PR DESCRIPTION
## Summary

fix changes affecting **1** file (Δ9 LOC).

Root cause: `libc=glibc` in `.npmrc` is a **pnpm** setting. npm ignores it entirely, so the previous fix never prevented the EBADPLATFORM error.

pnpm installs all platform variants of `sharp` (both glibc and musl) from the lockfile. Nitro traces node_modules and includes both in the generated `.output/server/package.json`. When `npm install` runs inside that directory, it EBADPLATFORM-fails on the musl packages (`wanted libc:musl, current: libc:glibc`).

Fix: after Nitro build, patch the generated `package.json` to remove the four musl-only `@img/sharp-*` entries before running `npm install`. Surgical — does not affect pnpm install or local development.

## Changes (1 commit)

- a8815a0 fix(ci): patch musl sharp packages from Nitro output before npm install

## Pre-PR Quality Gate

### Code Review: APPROVE

**Strengths:**
- Root cause diagnosis verified correct
- Musl package list complete and verified against `sharp@0.34.5` optionalDependencies
- Shell quoting correct (outer double-quotes, inner single-quotes for JS strings)
- Error propagation correct — missing package.json fails the step
- Defensive `(pkg.dependencies||{})` guard handles absent keys safely
- `--omit=dev` appropriate for Firebase Functions runtime

**Minor (non-blocking):**
- `console.log` fires unconditionally even if packages were absent
- Hardcoded list requires manual update if sharp adds a new musl arch

### Security Review: 0 High, 0 Medium

✅ No shell injection — script is a static literal with no variable expansion  
✅ No GitHub Actions expression injection in the new code  
✅ No path traversal — working-directory controlled by hardcoded workflow values  
✅ Reads/writes a build artifact, not source code  
✅ No supply chain risk — removes packages, does not add any  

### Observations

| Check | Status |
|-------|--------|
| Tests | ✅ N/A — CI config only, no src/lib changed |
| API Changes | ✅ None |
| Breaking Changes | ✅ None |
| Complexity | ✅ S (Δ9 LOC) |

## Test Plan

- [ ] Verify deploy runs after merge (trigger via workflow_dispatch with force_all_brands=true if needed)
- [ ] Confirm "Fix Firebase Functions dependencies" step logs "Removed musl packages: ..."
- [ ] Confirm `npm install --omit=dev` completes without EBADPLATFORM
- [ ] Confirm Firebase Functions deploy succeeds for all 3 brands
- [ ] Verify blog API routes are reachable in production