### PR TITLE
fix(ci): inject runtime env vars into Firebase Functions source before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,6 +228,14 @@ jobs:
           "
           npm install --omit=dev
 
+      - name: Inject runtime env vars into Firebase Functions source
+        working-directory: packages/${{ matrix.config.package }}
+        run: |
+          # Firebase CLI deploys .env files from the functions source directory as
+          # runtime environment variables. nuxt build does not read .env.prod (wrong name),
+          # so private runtimeConfig (NUXT_FIREBASE_*) would be empty at runtime without this.
+          cp .env.prod .output/server/.env
+
       - name: Deploy to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
## Summary

fix changes affecting **1** file (Δ8 LOC).

**Root cause of blog posts not appearing in production:**

`nuxt build` auto-reads `.env`, `.env.local`, `.env.production` — but NOT `.env.prod` (non-standard name). Private `runtimeConfig` values (`NUXT_FIREBASE_PROJECT_ID`, `NUXT_FIREBASE_CLIENT_EMAIL`, `NUXT_FIREBASE_PRIVATE_KEY`, `NUXT_FIREBASE_STORAGE_BUCKET`) were therefore **empty strings at Firebase Functions runtime**.

`getFirebaseApp()` validates all four values and throws `BlogApiError('Firebase configuration incomplete')` if any are missing. `loadDynamicPosts()` silently catches this error and returns `[]`. `/api/blog/posts` returns `{ success: true, count: 0, posts: [] }` with no visible error.

**Fix:** Copy `.env.prod` to `.output/server/.env` before `firebase deploy`. Firebase CLI reads `.env` files from `functions.source` (per `firebase.json`) and stores them as encrypted runtime environment variables in Cloud Run.

## Changes (1 commit)

- abc9a71 fix(ci): inject runtime env vars into Firebase Functions source before deploy

## Pre-PR Quality Gate

### Code Review: APPROVE

**Strengths:**
- Correct mechanism: Firebase CLI reads `.env` from `functions.source` (`.output/server/`)
- Step placed correctly: after Nitro build and sharp fix, before firebase deploy
- Comment accurately explains the root cause
- No change to build process or source code; purely additive to deploy pipeline

**Important (pre-existing, not introduced by this PR):**
- `.env.prod` includes `NUXT_PUBLIC_*` vars — Firebase CLI stores them encrypted in Cloud Run, no HTTP exposure, but broader than necessary
- `FIREBASE_PRIVATE_KEY` newline handling depends on how the secret is stored in GitHub Secrets. Code already handles `\\n→\n` conversion in `firebase-storage.ts:41`

### Security Review: 0 High, 0 Medium

✅ `.output/server/.env` covered by double gitignore (`.output/*` and `.env.*`)  
✅ GitHub Actions masks all `${{ secrets.* }}` values in logs  
✅ Firebase CLI stores env vars as encrypted Cloud Run runtime environment variables  
✅ Ephemeral runner — no persistent accessible storage  
✅ `.output/server/` is not the hosting public directory (no HTTP exposure)  

### Observations

| Check | Status |
|-------|--------|
| Tests | ✅ N/A — CI config only, no src/lib changed |
| API Changes | ✅ None |
| Breaking Changes | ✅ None |
| Complexity | ✅ S (Δ8 LOC) |

## Test Plan

- [ ] Verify deploy runs after merge (trigger via `workflow_dispatch` with `force_all_brands=true`)
- [ ] Confirm "Inject runtime env vars" step completes without error
- [ ] Confirm Firebase Functions initialization logs `firebase-storage-init` with correct bucket and projectId
- [ ] Confirm `/api/blog/posts` returns `count > 0` with actual posts
- [ ] Verify blog listing page renders posts in production