### PR TITLE
fix(ci): correct Firebase Storage bucket and .env location for Gen 2 functions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,7 +202,7 @@ jobs:
           echo "NUXT_GSC_CLIENT_SECRET=${{ secrets.GSC_CLIENT_SECRET }}" >> .env.prod
           echo "NUXT_GSC_REDIRECT_URI=https://${{ matrix.config.domain }}/api/auth/gsc/callback" >> .env.prod
           echo "NUXT_FIREBASE_PROJECT_ID=${{ matrix.config.firebase_project }}" >> .env.prod
-          echo "NUXT_FIREBASE_STORAGE_BUCKET=${{ matrix.config.firebase_project }}.appspot.com" >> .env.prod
+          echo "NUXT_FIREBASE_STORAGE_BUCKET=${{ matrix.config.firebase_project }}.firebasestorage.app" >> .env.prod
           echo "NUXT_FIREBASE_DATABASE_URL=https://${{ matrix.config.firebase_project }}-default-rtdb.firebaseio.com" >> .env.prod
           echo "NUXT_FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}" >> .env.prod
           echo "NUXT_FIREBASE_PRIVATE_KEY=${{ secrets.FIREBASE_PRIVATE_KEY }}" >> .env.prod
@@ -231,9 +231,10 @@ jobs:
       - name: Inject runtime env vars into Firebase Functions source
         working-directory: packages/${{ matrix.config.package }}
         run: |
-          # Firebase CLI deploys .env files from the functions source directory as
-          # runtime environment variables. nuxt build does not read .env.prod (wrong name),
-          # so private runtimeConfig (NUXT_FIREBASE_*) would be empty at runtime without this.
+          # Firebase CLI reads .env from the firebase.json directory (Gen 2 / Cloud Run)
+          # and from the functions source directory (Gen 1). Copy to both locations
+          # to be safe. nuxt build does not read .env.prod (non-standard name).
+          cp .env.prod .env
           cp .env.prod .output/server/.env
 
       - name: Deploy to Firebase Hosting


### PR DESCRIPTION
## Summary

fix: two independent bugs causing `/api/blog/posts` to silently return `{ count: 0, posts: [] }` even after all previous deploy fixes.

## Root Causes

### 1. Wrong Firebase Storage bucket name (confirmed)

`deploy.yml` was setting:
```
NUXT_FIREBASE_STORAGE_BUCKET=rentacar-403321.appspot.com
```

The actual bucket used everywhere in the codebase (verified across all 3 brands in `app.config.ts`, `nuxt.config.ts`, and components) is:
```
rentacar-403321.firebasestorage.app
```

Firebase Admin SDK was initializing with the `.appspot.com` bucket — a different GCS bucket where no blog posts exist. `listFilesInStorage()` returned `[]` silently (or threw an error silently caught by `loadDynamicPosts()`). Result: `count: 0`.

### 2. .env location wrong for Gen 2 Cloud Run functions

PR #156 copied `.env.prod` → `.output/server/.env` (functions source directory). For Firebase Functions Gen 2 (Cloud Run), as configured in `nuxt.config.ts:556` (`gen: 2`), Firebase CLI reads `.env` from the **firebase.json directory** (`packages/ui-{brand}/`), not only from the functions source. Now copies to both locations.

## Changes (1 commit)

- afbaebd fix(ci): correct Firebase Storage bucket name and .env location for Gen 2

## Evidence

All 3 brands consistently reference `rentacar-403321.firebasestorage.app`:
- `packages/ui-alquilatucarro/app/app.config.ts` - logo, og-logo, testimonial avatars
- `packages/ui-alquilatucarro/nuxt.config.ts` - preload link headers  
- `packages/ui-alquilatucarro/app/components/Images/Video.vue` - all video assets
- Same pattern in `ui-alquicarros` and `ui-alquilame`

## Test Plan

- [ ] Merge and trigger deploy via `workflow_dispatch` with `force_all_brands=true`
- [ ] Confirm step "Inject runtime env vars" logs show `.env` copied to both locations
- [ ] Confirm Firebase Functions log shows `firebase-storage-init` with bucket `rentacar-403321.firebasestorage.app`
- [ ] Confirm `/api/blog/posts` returns `count > 0`
- [ ] Confirm blog listing page renders posts on `alquilatucarro.com/blog`