### PR TITLE
fix: differentiate server errors from no-availability in search

### DIFF
--- a/packages/logic/src/composables/useFetchCategoriesAvailabilityData.ts
+++ b/packages/logic/src/composables/useFetchCategoriesAvailabilityData.ts
@@ -43,7 +43,14 @@ export default async function useFetchCategoriesAvailabilityData() {
     data.value = response;
   } catch (e: any) {
     const er = e as FetchError;
-    error.value = er.data as LocalizaErrorResponse;
+    if (er.data && typeof er.data === 'object' && 'error' in er.data) {
+      error.value = er.data as LocalizaErrorResponse;
+    } else {
+      error.value = {
+        error: 'server_error',
+        message: 'El servicio no está disponible en este momento. Por favor, intenta de nuevo en unos minutos.',
+      } as LocalizaErrorResponse;
+    }
   }
 
   return { data, error };

--- a/packages/logic/src/utils/types/data/LocalizaErrorResponse.ts
+++ b/packages/logic/src/utils/types/data/LocalizaErrorResponse.ts
@@ -11,6 +11,7 @@ export default interface LocalizaErrorResponse extends Response {
     | "inferior_pickup_date"
     | "inferior_return_date"
     | "unknown_error"
-    | "connection_timeout";
+    | "connection_timeout"
+    | "server_error";
   message: string;
 }

--- a/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquicarros/app/components/CategorySelectionSection.vue
@@ -1,5 +1,25 @@
 <template>
-  <div v-if="!hasAvailableCategories && !pendingSearch" class="text-center">
+  <div v-if="isServerError && !pendingSearch" class="text-center">
+    <div class="text-white text-center">
+      <div class="text-3xl">Servicio temporalmente no disponible</div>
+      <p class="text-lg mt-2">
+        Estamos experimentando problemas técnicos. Por favor, intenta de nuevo en unos minutos.
+      </p>
+      <p class="text-lg mt-2">Si deseas hacer una reserva, contáctanos:</p>
+      <p class="text-lg mt-1">
+        <a :href="`https://wa.me/57${whatsappContact.phone}`" target="_blank" rel="noopener" class="text-yellow-400 underline">
+          WhatsApp {{ whatsappContact.display }}
+        </a>
+      </p>
+      <p class="text-base mt-2 font-semibold">Horario de atención</p>
+      <p class="text-sm text-gray-300">
+        Lunes a viernes: 07:00am - 07:00pm<br>
+        Sábados: 07:00am - 04:00pm<br>
+        Domingos y festivos: Cerrado
+      </p>
+    </div>
+  </div>
+  <div v-else-if="!hasAvailableCategories && !pendingSearch" class="text-center">
     <div class="text-white text-center">
       <div class="text-3xl">¡Oops!</div>
       <div class="text-lg">
@@ -191,8 +211,18 @@ const {
   selectedCategory,
   filteredCategories,
   hasAvailableCategories,
+  error: searchError,
 } = storeToRefs(storeSearch);
 const { vehiculo, humanFormattedPickupDate, isSubmittingForm, selectedPickupLocation } = storeToRefs(storeForm);
+
+const isServerError = computed(() => searchError.value?.error === 'server_error');
+const config = useRuntimeConfig();
+const whatsappContacts: Record<string, { phone: string; display: string }> = {
+  alquilatucarro: { phone: "3016729250", display: "301 672 9250" },
+  alquilame: { phone: "3002436677", display: "300 243 6677" },
+  alquicarros: { phone: "3187703670", display: "318 770 3670" },
+};
+const whatsappContact = whatsappContacts[config.public.rentacarFranchise as string] ?? whatsappContacts.alquilatucarro;
 const { vehicleCategories } = useVehicleCategories();
 const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);

--- a/packages/ui-alquilame/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilame/app/components/CategorySelectionSection.vue
@@ -1,5 +1,25 @@
 <template>
-  <div v-if="!hasAvailableCategories && !pendingSearch" class="text-center">
+  <div v-if="isServerError && !pendingSearch" class="text-center">
+    <div class="text-white text-center">
+      <div class="text-3xl">Servicio temporalmente no disponible</div>
+      <p class="text-lg mt-2">
+        Estamos experimentando problemas técnicos. Por favor, intenta de nuevo en unos minutos.
+      </p>
+      <p class="text-lg mt-2">Si deseas hacer una reserva, contáctanos:</p>
+      <p class="text-lg mt-1">
+        <a :href="`https://wa.me/57${whatsappContact.phone}`" target="_blank" rel="noopener" class="text-yellow-400 underline">
+          WhatsApp {{ whatsappContact.display }}
+        </a>
+      </p>
+      <p class="text-base mt-2 font-semibold">Horario de atención</p>
+      <p class="text-sm text-gray-300">
+        Lunes a viernes: 07:00am - 07:00pm<br>
+        Sábados: 07:00am - 04:00pm<br>
+        Domingos y festivos: Cerrado
+      </p>
+    </div>
+  </div>
+  <div v-else-if="!hasAvailableCategories && !pendingSearch" class="text-center">
     <div class="text-white text-center">
       <div class="text-3xl">¡Oops!</div>
       <div class="text-lg">
@@ -191,8 +211,18 @@ const {
   selectedCategory,
   filteredCategories,
   hasAvailableCategories,
+  error: searchError,
 } = storeToRefs(storeSearch);
 const { vehiculo, humanFormattedPickupDate, isSubmittingForm, selectedPickupLocation } = storeToRefs(storeForm);
+
+const isServerError = computed(() => searchError.value?.error === 'server_error');
+const config = useRuntimeConfig();
+const whatsappContacts: Record<string, { phone: string; display: string }> = {
+  alquilatucarro: { phone: "3016729250", display: "301 672 9250" },
+  alquilame: { phone: "3002436677", display: "300 243 6677" },
+  alquicarros: { phone: "3187703670", display: "318 770 3670" },
+};
+const whatsappContact = whatsappContacts[config.public.rentacarFranchise as string] ?? whatsappContacts.alquilatucarro;
 const { vehicleCategories } = useVehicleCategories();
 const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);

--- a/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
+++ b/packages/ui-alquilatucarro/app/components/CategorySelectionSection.vue
@@ -1,5 +1,25 @@
 <template>
-  <div v-if="!hasAvailableCategories && !pendingSearch" class="text-center">
+  <div v-if="isServerError && !pendingSearch" class="text-center">
+    <div class="text-white text-center">
+      <div class="text-3xl">Servicio temporalmente no disponible</div>
+      <p class="text-lg mt-2">
+        Estamos experimentando problemas técnicos. Por favor, intenta de nuevo en unos minutos.
+      </p>
+      <p class="text-lg mt-2">Si deseas hacer una reserva, contáctanos:</p>
+      <p class="text-lg mt-1">
+        <a :href="`https://wa.me/57${whatsappContact.phone}`" target="_blank" rel="noopener" class="text-yellow-400 underline">
+          WhatsApp {{ whatsappContact.display }}
+        </a>
+      </p>
+      <p class="text-base mt-2 font-semibold">Horario de atención</p>
+      <p class="text-sm text-gray-300">
+        Lunes a viernes: 07:00am - 07:00pm<br>
+        Sábados: 07:00am - 04:00pm<br>
+        Domingos y festivos: Cerrado
+      </p>
+    </div>
+  </div>
+  <div v-else-if="!hasAvailableCategories && !pendingSearch" class="text-center">
     <div class="text-white text-center">
       <div class="text-3xl">¡Oops!</div>
       <div class="text-lg">
@@ -191,8 +211,18 @@ const {
   selectedCategory,
   filteredCategories,
   hasAvailableCategories,
+  error: searchError,
 } = storeToRefs(storeSearch);
 const { vehiculo, humanFormattedPickupDate, isSubmittingForm, selectedPickupLocation } = storeToRefs(storeForm);
+
+const isServerError = computed(() => searchError.value?.error === 'server_error');
+const config = useRuntimeConfig();
+const whatsappContacts: Record<string, { phone: string; display: string }> = {
+  alquilatucarro: { phone: "3016729250", display: "301 672 9250" },
+  alquilame: { phone: "3002436677", display: "300 243 6677" },
+  alquicarros: { phone: "3187703670", display: "318 770 3670" },
+};
+const whatsappContact = whatsappContacts[config.public.rentacarFranchise as string] ?? whatsappContacts.alquilatucarro;
 const { vehicleCategories } = useVehicleCategories();
 const slideoverReservationResume = ref<boolean>(false);
 const slideoverReservationForm = ref<boolean>(false);


### PR DESCRIPTION
## Summary

- When the availability API returns HTTP 500 (e.g. expired SSL certificate on the backend), the error was silently treated as "no cars available", showing the misleading "Oops! Nos quedamos sin carritos" message.
- Now differentiates between business errors (valid `LocalizaErrorResponse` with `error` field) and server/infrastructure errors (500 with null/HTML body).
- Server errors display a "Servicio temporalmente no disponible" message with WhatsApp contact per franchise and business hours.

## Changes

- `packages/logic/src/composables/useFetchCategoriesAvailabilityData.ts` — validate `er.data` shape before casting to `LocalizaErrorResponse`
- `packages/logic/src/utils/types/data/LocalizaErrorResponse.ts` — add `server_error` to error union type
- `packages/ui-*/app/components/CategorySelectionSection.vue` (3 files) — new `v-if` block for server errors with WhatsApp and schedule

## Test plan

- [ ] Verify normal search still shows available categories
- [ ] Verify "Oops sin carritos" still shows when API returns `no_available_categories_error`
- [ ] Verify server error (500) shows "Servicio no disponible" with WhatsApp contact
- [ ] Verify each franchise shows its own WhatsApp number