### PR TITLE
fix: exclude FU, FL, GL from monthly reservations (broken in operator)

### DIFF
--- a/packages/logic/src/stores/__tests__/useStoreSearchData.regression.test.ts
+++ b/packages/logic/src/stores/__tests__/useStoreSearchData.regression.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test for the FU/FL/GL monthly-reservation exclusion bug.
+ *
+ * Bug:
+ *   useStoreSearchData.ts used `categoryAdmin.identification in noMonthlyCategories`
+ *   to exclude FU, FL, GL from monthly reservations. The `in` operator checks object
+ *   keys / array indices, NOT array values. For `['FU', 'FL', 'GL']`:
+ *     - `'FU' in arr` → false (no key "FU", only 0, 1, 2)
+ *     - `!(false)`    → true  → category is INCLUDED
+ *   So the filter was a silent no-op: FU/FL/GL were always allowed through.
+ *
+ * This was invisible because:
+ *   1. The array `noMonthlyCategories` and the comment "filter out FU, FL, GL" made
+ *      the code look correct on review.
+ *   2. Localiza does not expose month_prices for these categories in rentacar-main,
+ *      so they rendered with fallback data, which looked "fine enough" until the
+ *      operations team noticed FU/GL were bookable monthly when they shouldn't be.
+ *
+ * Fix:
+ *   Replace `in` with `.includes()`, which tests array value membership correctly.
+ *
+ * Why this test is source-file based:
+ *   The buggy code lives inside a Pinia `defineStore` closure and depends on Nuxt
+ *   auto-imports (useRuntimeConfig, useFetch, #imports). Mounting the store in a
+ *   Node vitest environment requires a full Nuxt/Pinia test harness, which is
+ *   disproportionate for a one-line operator fix. A source-level assertion is the
+ *   smallest honest regression guard: it fails before the fix and protects against
+ *   anyone reverting to `in` later.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(
+  resolve(__dirname, '../useStoreSearchData.ts'),
+  'utf-8',
+);
+
+describe('useStoreSearchData — FU/FL/GL monthly exclusion regression', () => {
+  describe('S1: noMonthlyCategories array is declared', () => {
+    it('declares the exclusion list with FU, FL, GL', () => {
+      expect(source).toMatch(/noMonthlyCategories/);
+      expect(source).toMatch(/['"]FU['"]/);
+      expect(source).toMatch(/['"]FL['"]/);
+      expect(source).toMatch(/['"]GL['"]/);
+    });
+  });
+
+  describe('S2: filter uses .includes() (the fix)', () => {
+    it('uses Array.prototype.includes for value membership', () => {
+      expect(source).toMatch(/noMonthlyCategories\s*\.\s*includes\s*\(/);
+    });
+  });
+
+  describe('S3: filter does NOT use the `in` operator (the bug)', () => {
+    it('never tests `identification in noMonthlyCategories`', () => {
+      // `in` checks keys/indices on arrays — it is never the right operator for
+      // string-value membership in a string[] array.
+      expect(source).not.toMatch(/identification\s+in\s+noMonthlyCategories/);
+    });
+  });
+
+  describe('S4: filter is gated on haveMonthlyReservation', () => {
+    it('only applies the exclusion inside the monthly-reservation branch', () => {
+      // Keep the scope of the filter narrow: it must live in the monthly branch,
+      // not affect regular (daily) searches.
+      expect(source).toMatch(/haveMonthlyReservation\.value/);
+    });
+  });
+
+  describe('S5: JavaScript operator semantics documented', () => {
+    it('demonstrates why `in` was wrong for string arrays', () => {
+      const arr = ['FU', 'FL', 'GL'];
+      // `in` checks keys/indices, not values
+      expect('FU' in arr).toBe(false);
+      expect('FL' in arr).toBe(false);
+      expect('GL' in arr).toBe(false);
+      expect(0 in arr).toBe(true); // indices exist as keys
+      expect(1 in arr).toBe(true);
+      expect(2 in arr).toBe(true);
+    });
+
+    it('demonstrates why `.includes()` is correct for string arrays', () => {
+      const arr = ['FU', 'FL', 'GL'];
+      expect(arr.includes('FU')).toBe(true);
+      expect(arr.includes('FL')).toBe(true);
+      expect(arr.includes('GL')).toBe(true);
+      expect(arr.includes('C')).toBe(false);
+      expect(arr.includes('GY')).toBe(false);
+    });
+  });
+});

--- a/packages/logic/src/stores/useStoreSearchData.ts
+++ b/packages/logic/src/stores/useStoreSearchData.ts
@@ -68,7 +68,7 @@ const useStoreSearchData = defineStore("storeSearchData", () => {
       else {
         const dataArray = Array.isArray(data.value) ? data.value : [];
         categoriesAvailabilityData.value = categoriesAdminData?.filter((categoryAdmin: CategoryData) =>
-          !(categoryAdmin.identification in noMonthlyCategories)
+          !noMonthlyCategories.includes(categoryAdmin.identification)
         ) // filter out categories FU, FL and GL when have monthly reservation
         .map((categoryAdmin: CategoryData) =>
           // create a category availability object for each category


### PR DESCRIPTION
## Summary

Fixes a silent one-line bug in the monthly-reservation filter: FU, FL and GL were being shown (and bookable) for monthly searches in rentacar-main despite the code explicitly listing them as excluded.

### Root cause

\`packages/logic/src/stores/useStoreSearchData.ts:71\` used the \`in\` operator to test membership in a string array:

\`\`\`ts
const noMonthlyCategories: string[] = ['FU', 'FL', 'GL'];
// ...
!(categoryAdmin.identification in noMonthlyCategories)
\`\`\`

\`in\` checks **keys / indices**, not values. For \`['FU', 'FL', 'GL']\`:

- \`'FU' in arr\` → \`false\` (no key \`"FU"\`, only \`0, 1, 2\`)
- \`!(false)\` → \`true\` → category included

The filter was a silent no-op — the array and the inline comment looked correct, but nothing was actually excluded. Operations reported the mismatch vs rentacar-reservas, where the same logic is expressed as \`!=\` comparisons and works correctly.

### Fix

One-line operator swap:

\`\`\`diff
- !(categoryAdmin.identification in noMonthlyCategories)
+ !noMonthlyCategories.includes(categoryAdmin.identification)
\`\`\`

### Regression guard

Added \`src/stores/__tests__/useStoreSearchData.regression.test.ts\` — a source-file-based regression test that:

- Asserts \`.includes()\` is present in the filter
- Asserts the \`identification in noMonthlyCategories\` pattern is absent
- Documents the JS semantics of \`in\` vs \`.includes()\` with executable examples, so anyone tempted to revert the operator sees tests fail and reads the reason

Source-level assertions are used because the buggy code lives inside a Pinia \`defineStore\` closure depending on Nuxt auto-imports — mounting the store in the Node vitest environment would require a full Nuxt/Pinia harness, disproportionate for a one-character fix.

## Test plan

- [x] \`pnpm --filter @rentacar-main/logic test\` → 39/39 passing (6 new + 33 existing)
- [x] Red-phase verified: 2 of 6 new tests fail before the fix (S2 \`.includes()\` absent, S3 \`in\` present)
- [x] Green-phase verified: all 6 pass after the one-line fix
- [ ] Post-merge smoke test on preview: monthly search must NOT surface FU, FL, GL cards
- [ ] Post-merge smoke test on preview: daily search behavior unchanged (FU, FL, GL still available where applicable)