### PR TITLE
feat(reservas): migrate to rentacar-dashboard via server proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,9 +194,11 @@ jobs:
           echo "NUXT_PUBLIC_FIREBASE_API_KEY=${{ secrets.NUXT_PUBLIC_FIREBASE_API_KEY }}" >> .env.prod
           echo "NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${{ secrets.NUXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}" >> .env.prod
           echo "NUXT_PUBLIC_FIREBASE_PROJECT_ID=${{ matrix.config.firebase_project }}" >> .env.prod
-          echo "NUXT_PUBLIC_RENTACAR_API_RESERVAS_DATA_ENDPOINT=${{ secrets.NUXT_PUBLIC_RENTACAR_API_RESERVAS_DATA_ENDPOINT }}" >> .env.prod
-          echo "NUXT_PUBLIC_RENTACAR_API_RESERVAS_FORM_RECORD_ENDPOINT=${{ secrets.NUXT_PUBLIC_RENTACAR_API_RESERVAS_FORM_RECORD_ENDPOINT }}" >> .env.prod
-          echo "NUXT_PUBLIC_RENTACAR_API_RESERVAS_CATEGORIES_AVAILABILITY_ENDPOINT=${{ secrets.NUXT_PUBLIC_RENTACAR_API_RESERVAS_CATEGORIES_AVAILABILITY_ENDPOINT }}" >> .env.prod
+          # Reservation backend (rentacar-dashboard) — server-only.
+          # The browser hits the local /api/reservas/* proxy (default in nuxt.config.ts),
+          # which forwards here with the x-api-key header.
+          echo "NUXT_RENTACAR_DASHBOARD_BASE_URL=${{ secrets.NUXT_RENTACAR_DASHBOARD_BASE_URL }}" >> .env.prod
+          echo "NUXT_RENTACAR_API_KEY=${{ secrets.NUXT_RENTACAR_API_KEY }}" >> .env.prod
           echo "NUXT_SEO_PASSWORD=${{ secrets.SEO_PASSWORD }}" >> .env.prod
           echo "NUXT_GSC_CLIENT_ID=${{ secrets.GSC_CLIENT_ID }}" >> .env.prod
           echo "NUXT_GSC_CLIENT_SECRET=${{ secrets.GSC_CLIENT_SECRET }}" >> .env.prod

--- a/packages/logic/src/utils/__tests__/dashboardStatus.test.ts
+++ b/packages/logic/src/utils/__tests__/dashboardStatus.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { mapDashboardReservationStatus } from '../dashboardStatus';
+
+describe('mapDashboardReservationStatus', () => {
+  it('maps reservado → Confirmado', () => {
+    expect(mapDashboardReservationStatus('reservado')).toBe('Confirmado');
+  });
+
+  it('maps pendiente → Pendiente', () => {
+    expect(mapDashboardReservationStatus('pendiente')).toBe('Pendiente');
+  });
+
+  it('maps mensualidad → Pendiente (legacy parity)', () => {
+    expect(mapDashboardReservationStatus('mensualidad')).toBe('Pendiente');
+  });
+
+  it('maps sin_disponibilidad → Sin disponibilidad', () => {
+    expect(mapDashboardReservationStatus('sin_disponibilidad')).toBe('Sin disponibilidad');
+  });
+
+  it('normalizes casing and whitespace', () => {
+    expect(mapDashboardReservationStatus('Reservado')).toBe('Confirmado');
+    expect(mapDashboardReservationStatus('PENDIENTE')).toBe('Pendiente');
+    expect(mapDashboardReservationStatus('  mensualidad  ')).toBe('Pendiente');
+  });
+
+  it('falls back to Pendiente for unknown values (incl. dashboard-only states)', () => {
+    expect(mapDashboardReservationStatus('algo_raro')).toBe('Pendiente');
+    expect(mapDashboardReservationStatus('nueva')).toBe('Pendiente');
+    expect(mapDashboardReservationStatus('cancelado')).toBe('Pendiente');
+  });
+
+  it('falls back to Pendiente for null/undefined/empty', () => {
+    expect(mapDashboardReservationStatus(null)).toBe('Pendiente');
+    expect(mapDashboardReservationStatus(undefined)).toBe('Pendiente');
+    expect(mapDashboardReservationStatus('')).toBe('Pendiente');
+  });
+});

--- a/packages/logic/src/utils/dashboardStatus.ts
+++ b/packages/logic/src/utils/dashboardStatus.ts
@@ -1,0 +1,27 @@
+import type { ReservationApiStatus } from './types/data/ReservationApiStatus';
+
+const DASHBOARD_TO_LEGACY: Record<string, ReservationApiStatus> = {
+  reservado: 'Confirmado',
+  pendiente: 'Pendiente',
+  mensualidad: 'Pendiente',
+  sin_disponibilidad: 'Sin disponibilidad',
+};
+
+// Fallback to "Pendiente" because the store consumer
+// (useStoreReservationForm.ts:213-217) only branches on Pendiente/Confirmado;
+// any other value strands the user on the form. Ops should monitor logs for
+// unmapped values to detect dashboard-side enum drift.
+export function mapDashboardReservationStatus(
+  raw: string | null | undefined,
+): ReservationApiStatus {
+  if (!raw) return 'Pendiente';
+  const key = raw.trim().toLowerCase();
+  const mapped = DASHBOARD_TO_LEGACY[key];
+  if (mapped) return mapped;
+  if (typeof console !== 'undefined') {
+    console.warn(
+      `[dashboardStatus] unmapped reservationStatus="${raw}" → falling back to "Pendiente"`,
+    );
+  }
+  return 'Pendiente';
+}

--- a/packages/logic/src/utils/index.ts
+++ b/packages/logic/src/utils/index.ts
@@ -20,6 +20,11 @@ export * from './useValidateFunctions';
 export { slugify } from './slugify';
 
 // ============================================================================
+// Dashboard Status Mapping
+// ============================================================================
+export { mapDashboardReservationStatus } from './dashboardStatus';
+
+// ============================================================================
 // Type Definitions - Data
 // ============================================================================
 export type { default as BranchData } from './types/data/BranchData';

--- a/packages/ui-alquicarros/nuxt.config.ts
+++ b/packages/ui-alquicarros/nuxt.config.ts
@@ -479,12 +479,17 @@ export default defineNuxtConfig({
     // Blog API security
     blogApiKey: '',
     blogApiAllowedIps: '',
+    // rentacar-dashboard reservation backend (server-only — keeps the
+    // x-api-key out of the client bundle). The browser hits the local
+    // /api/reservas/* proxy; the proxy forwards here.
+    // Override with NUXT_RENTACAR_DASHBOARD_BASE_URL, NUXT_RENTACAR_API_KEY.
+    rentacarDashboardBaseUrl: '',
+    rentacarApiKey: '',
     // Public config (exposed to client)
     public: {
       rentacarFranchise: "alquicarros",
-      rentacarApiReservasDataEndpoint: "",
-      rentacarApiReservasFormRecordEndpoint: "",
-      rentacarApiReservasCategoriesAvailabilityEndpoint: "",
+      rentacarApiReservasFormRecordEndpoint: "/api/reservas/record",
+      rentacarApiReservasCategoriesAvailabilityEndpoint: "/api/reservas/availability",
       isTest: process.env.NODE_ENV === "test",
     },
   },

--- a/packages/ui-alquicarros/server/api/reservas/availability.post.ts
+++ b/packages/ui-alquicarros/server/api/reservas/availability.post.ts
@@ -1,0 +1,40 @@
+/**
+ * Server proxy: availability lookup against rentacar-dashboard.
+ * Keeps RESERVATION_API_KEY server-side and adds the x-api-key header
+ * the dashboard requires. Body is forwarded as-is.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const baseUrl = config.rentacarDashboardBaseUrl
+  const apiKey = config.rentacarApiKey
+
+  if (!baseUrl || !apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Reservation backend not configured',
+    })
+  }
+
+  const body = await readBody(event)
+  const upstream = new URL('/api/reservations/availability', baseUrl).toString()
+
+  try {
+    return await $fetch(upstream, {
+      method: 'POST',
+      headers: { 'x-api-key': apiKey },
+      body,
+      timeout: 10_000,
+      retry: 0,
+    })
+  } catch (e: any) {
+    const status = e?.response?.status ?? 502
+    throw createError({
+      statusCode: status,
+      statusMessage: e?.statusMessage || 'Upstream availability error',
+      data: e?.data ?? {
+        error: 'upstream_error',
+        message: 'El servicio no está disponible en este momento. Por favor, intenta de nuevo en unos minutos.',
+      },
+    })
+  }
+})

--- a/packages/ui-alquicarros/server/api/reservas/record.post.ts
+++ b/packages/ui-alquicarros/server/api/reservas/record.post.ts
@@ -1,0 +1,52 @@
+import { mapDashboardReservationStatus } from '@rentacar-main/logic/utils'
+
+/**
+ * Server proxy: reservation record against rentacar-dashboard.
+ * Translates the dashboard's status vocabulary (reservado / pendiente /
+ * mensualidad) into the legacy Pendiente / Confirmado / Sin disponibilidad
+ * surface the rentacar-main store consumes. Keeps RESERVATION_API_KEY
+ * server-side.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const baseUrl = config.rentacarDashboardBaseUrl
+  const apiKey = config.rentacarApiKey
+
+  if (!baseUrl || !apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Reservation backend not configured',
+    })
+  }
+
+  const body = await readBody(event)
+  const upstreamUrl = new URL('/api/reservations', baseUrl).toString()
+
+  try {
+    const upstream = await $fetch<{ reserveCode: string; reservationStatus: string }>(
+      upstreamUrl,
+      {
+        method: 'POST',
+        headers: { 'x-api-key': apiKey },
+        body,
+        timeout: 10_000,
+        retry: 0,
+      },
+    )
+
+    return {
+      reserveCode: upstream.reserveCode,
+      reservationStatus: mapDashboardReservationStatus(upstream.reservationStatus),
+    }
+  } catch (e: any) {
+    const status = e?.response?.status ?? 502
+    throw createError({
+      statusCode: status,
+      statusMessage: e?.statusMessage || 'Upstream reservation error',
+      data: e?.data ?? {
+        error: 'upstream_error',
+        message: 'No se pudo registrar la reserva. Por favor, intenta de nuevo en unos minutos.',
+      },
+    })
+  }
+})

--- a/packages/ui-alquilame/nuxt.config.ts
+++ b/packages/ui-alquilame/nuxt.config.ts
@@ -478,12 +478,17 @@ export default defineNuxtConfig({
     firebaseDatabaseUrl: '',
     blogApiKey: '',
     blogApiAllowedIps: '',
+    // rentacar-dashboard reservation backend (server-only — keeps the
+    // x-api-key out of the client bundle). The browser hits the local
+    // /api/reservas/* proxy; the proxy forwards here.
+    // Override with NUXT_RENTACAR_DASHBOARD_BASE_URL, NUXT_RENTACAR_API_KEY.
+    rentacarDashboardBaseUrl: '',
+    rentacarApiKey: '',
     // Public config (exposed to client)
     public: {
       rentacarFranchise: "alquilame",
-      rentacarApiReservasDataEndpoint: "",
-      rentacarApiReservasFormRecordEndpoint: "",
-      rentacarApiReservasCategoriesAvailabilityEndpoint: "",
+      rentacarApiReservasFormRecordEndpoint: "/api/reservas/record",
+      rentacarApiReservasCategoriesAvailabilityEndpoint: "/api/reservas/availability",
       isTest: process.env.NODE_ENV === "test",
     },
   },

--- a/packages/ui-alquilame/server/api/reservas/availability.post.ts
+++ b/packages/ui-alquilame/server/api/reservas/availability.post.ts
@@ -1,0 +1,40 @@
+/**
+ * Server proxy: availability lookup against rentacar-dashboard.
+ * Keeps RESERVATION_API_KEY server-side and adds the x-api-key header
+ * the dashboard requires. Body is forwarded as-is.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const baseUrl = config.rentacarDashboardBaseUrl
+  const apiKey = config.rentacarApiKey
+
+  if (!baseUrl || !apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Reservation backend not configured',
+    })
+  }
+
+  const body = await readBody(event)
+  const upstream = new URL('/api/reservations/availability', baseUrl).toString()
+
+  try {
+    return await $fetch(upstream, {
+      method: 'POST',
+      headers: { 'x-api-key': apiKey },
+      body,
+      timeout: 10_000,
+      retry: 0,
+    })
+  } catch (e: any) {
+    const status = e?.response?.status ?? 502
+    throw createError({
+      statusCode: status,
+      statusMessage: e?.statusMessage || 'Upstream availability error',
+      data: e?.data ?? {
+        error: 'upstream_error',
+        message: 'El servicio no está disponible en este momento. Por favor, intenta de nuevo en unos minutos.',
+      },
+    })
+  }
+})

--- a/packages/ui-alquilame/server/api/reservas/record.post.ts
+++ b/packages/ui-alquilame/server/api/reservas/record.post.ts
@@ -1,0 +1,52 @@
+import { mapDashboardReservationStatus } from '@rentacar-main/logic/utils'
+
+/**
+ * Server proxy: reservation record against rentacar-dashboard.
+ * Translates the dashboard's status vocabulary (reservado / pendiente /
+ * mensualidad) into the legacy Pendiente / Confirmado / Sin disponibilidad
+ * surface the rentacar-main store consumes. Keeps RESERVATION_API_KEY
+ * server-side.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const baseUrl = config.rentacarDashboardBaseUrl
+  const apiKey = config.rentacarApiKey
+
+  if (!baseUrl || !apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Reservation backend not configured',
+    })
+  }
+
+  const body = await readBody(event)
+  const upstreamUrl = new URL('/api/reservations', baseUrl).toString()
+
+  try {
+    const upstream = await $fetch<{ reserveCode: string; reservationStatus: string }>(
+      upstreamUrl,
+      {
+        method: 'POST',
+        headers: { 'x-api-key': apiKey },
+        body,
+        timeout: 10_000,
+        retry: 0,
+      },
+    )
+
+    return {
+      reserveCode: upstream.reserveCode,
+      reservationStatus: mapDashboardReservationStatus(upstream.reservationStatus),
+    }
+  } catch (e: any) {
+    const status = e?.response?.status ?? 502
+    throw createError({
+      statusCode: status,
+      statusMessage: e?.statusMessage || 'Upstream reservation error',
+      data: e?.data ?? {
+        error: 'upstream_error',
+        message: 'No se pudo registrar la reserva. Por favor, intenta de nuevo en unos minutos.',
+      },
+    })
+  }
+})

--- a/packages/ui-alquilatucarro/nuxt.config.ts
+++ b/packages/ui-alquilatucarro/nuxt.config.ts
@@ -503,12 +503,17 @@ export default defineNuxtConfig({
     // Override with NUXT_BLOG_API_* env vars
     blogApiKey: '',
     blogApiAllowedIps: '',
+    // rentacar-dashboard reservation backend (server-only — keeps the
+    // x-api-key out of the client bundle). The browser hits the local
+    // /api/reservas/* proxy; the proxy forwards here.
+    // Override with NUXT_RENTACAR_DASHBOARD_BASE_URL, NUXT_RENTACAR_API_KEY.
+    rentacarDashboardBaseUrl: '',
+    rentacarApiKey: '',
     // Public config (exposed to client)
     public: {
       rentacarFranchise: "alquilatucarro",
-      rentacarApiReservasDataEndpoint: "",
-      rentacarApiReservasFormRecordEndpoint: "",
-      rentacarApiReservasCategoriesAvailabilityEndpoint: "",
+      rentacarApiReservasFormRecordEndpoint: "/api/reservas/record",
+      rentacarApiReservasCategoriesAvailabilityEndpoint: "/api/reservas/availability",
       isTest: process.env.NODE_ENV === "test",
     },
   },

--- a/packages/ui-alquilatucarro/server/api/reservas/availability.post.ts
+++ b/packages/ui-alquilatucarro/server/api/reservas/availability.post.ts
@@ -1,0 +1,40 @@
+/**
+ * Server proxy: availability lookup against rentacar-dashboard.
+ * Keeps RESERVATION_API_KEY server-side and adds the x-api-key header
+ * the dashboard requires. Body is forwarded as-is.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const baseUrl = config.rentacarDashboardBaseUrl
+  const apiKey = config.rentacarApiKey
+
+  if (!baseUrl || !apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Reservation backend not configured',
+    })
+  }
+
+  const body = await readBody(event)
+  const upstream = new URL('/api/reservations/availability', baseUrl).toString()
+
+  try {
+    return await $fetch(upstream, {
+      method: 'POST',
+      headers: { 'x-api-key': apiKey },
+      body,
+      timeout: 10_000,
+      retry: 0,
+    })
+  } catch (e: any) {
+    const status = e?.response?.status ?? 502
+    throw createError({
+      statusCode: status,
+      statusMessage: e?.statusMessage || 'Upstream availability error',
+      data: e?.data ?? {
+        error: 'upstream_error',
+        message: 'El servicio no está disponible en este momento. Por favor, intenta de nuevo en unos minutos.',
+      },
+    })
+  }
+})

--- a/packages/ui-alquilatucarro/server/api/reservas/record.post.ts
+++ b/packages/ui-alquilatucarro/server/api/reservas/record.post.ts
@@ -1,0 +1,52 @@
+import { mapDashboardReservationStatus } from '@rentacar-main/logic/utils'
+
+/**
+ * Server proxy: reservation record against rentacar-dashboard.
+ * Translates the dashboard's status vocabulary (reservado / pendiente /
+ * mensualidad) into the legacy Pendiente / Confirmado / Sin disponibilidad
+ * surface the rentacar-main store consumes. Keeps RESERVATION_API_KEY
+ * server-side.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const baseUrl = config.rentacarDashboardBaseUrl
+  const apiKey = config.rentacarApiKey
+
+  if (!baseUrl || !apiKey) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Reservation backend not configured',
+    })
+  }
+
+  const body = await readBody(event)
+  const upstreamUrl = new URL('/api/reservations', baseUrl).toString()
+
+  try {
+    const upstream = await $fetch<{ reserveCode: string; reservationStatus: string }>(
+      upstreamUrl,
+      {
+        method: 'POST',
+        headers: { 'x-api-key': apiKey },
+        body,
+        timeout: 10_000,
+        retry: 0,
+      },
+    )
+
+    return {
+      reserveCode: upstream.reserveCode,
+      reservationStatus: mapDashboardReservationStatus(upstream.reservationStatus),
+    }
+  } catch (e: any) {
+    const status = e?.response?.status ?? 502
+    throw createError({
+      statusCode: status,
+      statusMessage: e?.statusMessage || 'Upstream reservation error',
+      data: e?.data ?? {
+        error: 'upstream_error',
+        message: 'No se pudo registrar la reserva. Por favor, intenta de nuevo en unos minutos.',
+      },
+    })
+  }
+})


### PR DESCRIPTION
## Summary

Migrate the public reservation API (availability lookup + record reservation) from the legacy Laravel backend (`rentacar-admin`) to the new Next.js `rentacar-dashboard`, without touching the dashboard or the public composables.

- **Server proxies** in each brand (`packages/ui-*/server/api/reservas/{availability,record}.post.ts`) attach the `x-api-key` header server-side, so the secret never reaches the browser bundle. Composables `useFetchCategoriesAvailabilityData` and `useRecordReservationForm` stay untouched — public endpoint vars now default to the local proxy paths.
- **Status mapper** (`packages/logic/src/utils/dashboardStatus.ts`, 7 vitest cases) translates the dashboard vocabulary (`reservado` / `pendiente` / `mensualidad` / `sin_disponibilidad`) into the legacy `ReservationApiStatus` (`Confirmado` / `Pendiente` / `Sin disponibilidad`) the store consumes. Includes case normalization and a `console.warn` when an unknown value is seen, to surface dashboard-side enum drift in logs.
- **CI**: `deploy.yml` drops the three `NUXT_PUBLIC_RENTACAR_API_RESERVAS_*` secrets (legacy URLs) and injects the two new server-only secrets (`NUXT_RENTACAR_DASHBOARD_BASE_URL`, `NUXT_RENTACAR_API_KEY`).

## Pre-merge requirements

The two new repository secrets must already exist in GitHub Actions before this merges (they do — added 2 hours ago):

- `NUXT_RENTACAR_DASHBOARD_BASE_URL`
- `NUXT_RENTACAR_API_KEY`

## Test plan

- [x] Vitest unit suite passes (46/46 — covers every dashboard enum value + case variants + null/empty + unknown fallback).
- [x] Dev server (`pnpm dev:alquilatucarro`) against the live `rentacar-dashboard` dev backend:
  - [x] Availability search returns categories.
  - [x] Regular reservation completes (`reservado` → `Confirmado` → `/reservado/<code>`).
  - [x] Monthly reservation completes (`mensualidad` → `Pendiente` → `/pendiente`).
- [ ] After merge: confirm the deploy succeeds for all three brands; smoke-test the booking flow on each domain in production.
- [ ] Cleanup: delete the three legacy `NUXT_PUBLIC_RENTACAR_API_RESERVAS_*` repository secrets once production is validated.